### PR TITLE
feat: add opt-in TUI mouse navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ kanban-md tui             # launch from any directory with a kanban/ board
 kanban-md tui --dir PATH  # point to a specific kanban directory
 kanban-md tui --hide-empty-columns  # override config and hide empty columns
 kanban-md tui --show-empty-columns  # override config and show empty columns
+kanban-md tui --mouse      # opt in to mouse navigation
 ```
 
 Set `tui.hide_empty_columns` in `config.yml` to control the default behavior.
@@ -521,6 +522,17 @@ Set `tui.hide_empty_columns` in `config.yml` to control the default behavior.
 > **Note:** Older releases shipped a standalone `kanban-md-tui` binary. It has been retired — use `kanban-md tui` instead.
 
 In create/edit dialogs, text fields support cursor-based editing (`←/→`, `Home/End`, `Backspace`, `Delete`).
+
+Mouse mode is disabled by default. With `--mouse`, click a card to select it,
+double-click the same card within 500 ms to open its detail view, and click
+`Back` to return to the board. The wheel moves the selection one task at a
+time in the hovered column and scrolls task details three lines at a time.
+Keyboard controls remain available in mouse mode.
+
+Terminals commonly reserve a modifier such as Shift or Option/Alt to bypass
+application mouse reporting for native text selection. The exact modifier is
+terminal-dependent; use the terminal's normal selection shortcut or omit
+`--mouse` when native selection is preferred.
 
 ### Keyboard shortcuts
 

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -18,19 +18,29 @@ import (
 	"github.com/antopolskiy/kanban-md/internal/watcher"
 )
 
-var tuiCmd = &cobra.Command{
-	Use:   "tui",
-	Short: "Open the interactive board UI",
-	Long: `Launches the interactive terminal UI for browsing and managing the
+var tuiCmd = newTUICommand()
+
+func newTUICommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tui",
+		Short: "Open the interactive board UI",
+		Long: `Launches the interactive terminal UI for browsing and managing the
 kanban board. The board live-reloads when task files change on disk.
 
 Navigate with arrow keys or vim-style h/j/k/l, press ? for help.`,
-	RunE: runTUI,
+		RunE: runTUI,
+	}
+	addTUIFlags(cmd)
+	return cmd
+}
+
+func addTUIFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("hide-empty-columns", false, "hide empty columns in TUI (overrides config)")
+	cmd.Flags().Bool("show-empty-columns", false, "show empty columns in TUI (overrides config)")
+	cmd.Flags().Bool("mouse", false, "enable mouse navigation in TUI")
 }
 
 func init() {
-	tuiCmd.Flags().Bool("hide-empty-columns", false, "hide empty columns in TUI (overrides config)")
-	tuiCmd.Flags().Bool("show-empty-columns", false, "show empty columns in TUI (overrides config)")
 	rootCmd.AddCommand(tuiCmd)
 }
 
@@ -39,14 +49,12 @@ func RunTUI(dir string) error {
 	if dir != "" {
 		flagDir = dir
 	}
-	return runTUI(tuiCmd, nil)
+	return runTUI(newTUICommand(), nil)
 }
 
 func runTUI(cmd *cobra.Command, _ []string) error {
 	if cmd == nil {
-		cmd = &cobra.Command{Use: "tui"}
-		cmd.Flags().Bool("hide-empty-columns", false, "")
-		cmd.Flags().Bool("show-empty-columns", false, "")
+		cmd = newTUICommand()
 	}
 
 	cfg, err := loadConfig()
@@ -65,10 +73,20 @@ func runTUI(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	mouseEnabled, err := cmd.Flags().GetBool("mouse")
+	if err != nil {
+		return err
+	}
 
 	model := tui.NewBoard(cfg)
 	model.SetHideEmptyColumns(hideEmptyColumns)
-	p := tea.NewProgram(model, tea.WithAltScreen())
+	model.SetMouseEnabled(mouseEnabled)
+
+	programOptions := []tea.ProgramOption{tea.WithAltScreen()}
+	if mouseEnabled {
+		programOptions = append(programOptions, tea.WithMouseCellMotion())
+	}
+	p := tea.NewProgram(model, programOptions...)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/tui_test.go
+++ b/cmd/tui_test.go
@@ -359,10 +359,36 @@ func newTUIFlagTestCmd(t *testing.T, args ...string) *cobra.Command {
 	cmd := &cobra.Command{Use: "tui"}
 	cmd.Flags().Bool("hide-empty-columns", false, "")
 	cmd.Flags().Bool("show-empty-columns", false, "")
+	cmd.Flags().Bool("mouse", false, "")
 	if err := cmd.ParseFlags(args); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
 	return cmd
+}
+
+func TestTUICommandMouseFlagDefaultsOff(t *testing.T) {
+	cmd := newTUICommand()
+	enabled, err := cmd.Flags().GetBool("mouse")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if enabled {
+		t.Fatal("--mouse should be disabled by default")
+	}
+}
+
+func TestTUICommandMouseFlagCanBeEnabled(t *testing.T) {
+	cmd := newTUICommand()
+	if err := cmd.ParseFlags([]string{"--mouse"}); err != nil {
+		t.Fatal(err)
+	}
+	enabled, err := cmd.Flags().GetBool("mouse")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enabled {
+		t.Fatal("--mouse did not enable mouse mode")
+	}
 }
 
 func TestResolveHideEmptyColumns_DefaultFromConfig(t *testing.T) {

--- a/e2e/tui_harness_test.go
+++ b/e2e/tui_harness_test.go
@@ -4,6 +4,7 @@ package e2e_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -49,6 +50,25 @@ func (b *tuiOutputBuffer) String() string {
 	return b.buf.String()
 }
 
+func (b *tuiOutputBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Len()
+}
+
+func (b *tuiOutputBuffer) StringFrom(offset int) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	raw := b.buf.String()
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(raw) {
+		offset = len(raw)
+	}
+	return raw[offset:]
+}
+
 type tuiSession struct {
 	t       *testing.T
 	cmd     *exec.Cmd
@@ -59,13 +79,33 @@ type tuiSession struct {
 	cleanup sync.Once
 }
 
+type tuiProcessOptions struct {
+	args []string
+	rows uint16
+	cols uint16
+}
+
 func startTUIProcess(t *testing.T, dir string) *tuiSession {
 	t.Helper()
+	return startTUIProcessWithOptions(t, dir, tuiProcessOptions{})
+}
 
-	cmd := exec.Command(binPath, "--dir", dir, "tui") //nolint:gosec,noctx // command uses test-built binary path
+func startTUIProcessWithOptions(t *testing.T, dir string, options tuiProcessOptions) *tuiSession {
+	t.Helper()
+
+	rows := options.rows
+	if rows == 0 {
+		rows = tuiRows
+	}
+	cols := options.cols
+	if cols == 0 {
+		cols = tuiCols
+	}
+	args := append([]string{"--dir", dir, "tui"}, options.args...)
+	cmd := exec.Command(binPath, args...) //nolint:gosec,noctx // command uses test-built binary path
 	cmd.Env = append(os.Environ(), "NO_COLOR=1", "TERM=dumb")
 
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: tuiCols, Rows: tuiRows})
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: cols, Rows: rows})
 	if err != nil {
 		t.Fatalf("starting TUI process: %v", err)
 	}
@@ -129,16 +169,30 @@ func (s *tuiSession) output() string {
 	return sanitizeTTYOutput(s.out.String())
 }
 
-func (s *tuiSession) pressKey(name string) error {
+func (s *tuiSession) checkpoint() int {
+	return s.out.Len()
+}
+
+func (s *tuiSession) outputSince(checkpoint int) string {
+	return sanitizeTTYOutput(s.out.StringFrom(checkpoint))
+}
+
+func (s *tuiSession) rawOutputSince(checkpoint int) string {
+	return s.out.StringFrom(checkpoint)
+}
+
+func (s *tuiSession) writeRaw(input []byte) error {
 	s.t.Helper()
-	_, err := s.ptmx.Write([]byte(encodeKey(name)))
-	if err != nil {
-		return err
-	}
-	if s.t != nil {
+	_, err := s.ptmx.Write(input)
+	if err == nil {
 		time.Sleep(tuiKeyDelay)
 	}
-	return nil
+	return err
+}
+
+func (s *tuiSession) pressKey(name string) error {
+	s.t.Helper()
+	return s.writeRaw([]byte(encodeKey(name)))
 }
 
 func (s *tuiSession) pressKeys(names ...string) {
@@ -182,6 +236,92 @@ func (s *tuiSession) waitForOutput(needle string) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	s.t.Fatalf("timed out waiting for output containing %q; got %q", needle, s.output())
+}
+
+func (s *tuiSession) waitForOutputSince(checkpoint int, needle string) {
+	s.t.Helper()
+	deadline := time.Now().Add(tuiStartupTimeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(s.outputSince(checkpoint), needle) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	s.t.Fatalf("timed out waiting for new output containing %q; got %q", needle, s.outputSince(checkpoint))
+}
+
+func (s *tuiSession) waitForRawOutput(needle string) {
+	s.t.Helper()
+	s.waitForRawOutputSince(0, needle)
+}
+
+func (s *tuiSession) waitForRawOutputSince(checkpoint int, needle string) {
+	s.t.Helper()
+	deadline := time.Now().Add(tuiStartupTimeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(s.rawOutputSince(checkpoint), needle) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	s.t.Fatalf("timed out waiting for raw output containing %q; got %q", needle, s.rawOutputSince(checkpoint))
+}
+
+func (s *tuiSession) resize(cols, rows uint16) {
+	s.t.Helper()
+	if err := pty.Setsize(s.ptmx, &pty.Winsize{Cols: cols, Rows: rows}); err != nil {
+		s.t.Fatalf("resizing PTY to %dx%d: %v", cols, rows, err)
+	}
+	time.Sleep(tuiKeyDelay)
+}
+
+func (s *tuiSession) mouseSGR(code, x, y int, release bool) {
+	s.t.Helper()
+	final := byte('M')
+	if release {
+		final = 'm'
+	}
+	sequence := []byte(fmt.Sprintf("\x1b[<%d;%d;%d%c", code, x+1, y+1, final))
+	if err := s.writeRaw(sequence); err != nil {
+		s.t.Fatalf("writing SGR mouse event: %v", err)
+	}
+}
+
+func (s *tuiSession) mouseX10(code, x, y int) {
+	s.t.Helper()
+	if code < 0 || code > 223 || x < 0 || x > 222 || y < 0 || y > 222 {
+		s.t.Fatalf("X10 mouse coordinate/code out of range: code=%d x=%d y=%d", code, x, y)
+	}
+	sequence := []byte{
+		0x1b, '[', 'M',
+		byte(32 + code),  // #nosec G115 -- range checked above
+		byte(32 + x + 1), // #nosec G115 -- range checked above
+		byte(32 + y + 1), // #nosec G115 -- range checked above
+	}
+	if err := s.writeRaw(sequence); err != nil {
+		s.t.Fatalf("writing X10 mouse event: %v", err)
+	}
+}
+
+func (s *tuiSession) clickSGR(x, y int) {
+	s.t.Helper()
+	s.mouseSGR(0, x, y, false)
+	s.mouseSGR(0, x, y, true)
+}
+
+func (s *tuiSession) clickX10(x, y int) {
+	s.t.Helper()
+	s.mouseX10(0, x, y)
+	s.mouseX10(3, x, y)
+}
+
+func (s *tuiSession) wheelSGR(x, y, direction int) {
+	s.t.Helper()
+	code := 64
+	if direction > 0 {
+		code = 65
+	}
+	s.mouseSGR(code, x, y, false)
 }
 
 func (s *tuiSession) waitForExit() {

--- a/e2e/tui_mouse_navigation_test.go
+++ b/e2e/tui_mouse_navigation_test.go
@@ -1,0 +1,93 @@
+//go:build !windows
+
+package e2e_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestE2E_TUIMouse_DoubleClickDetailBackAndKeyboardSync(t *testing.T) {
+	kanbanDir := initBoardWithSeededTasks(t)
+	session := startTUIProcessWithOptions(t, kanbanDir, tuiProcessOptions{
+		args: []string{"--mouse"},
+	})
+	session.waitForRawOutput("\x1b[?1002h")
+	session.waitForOutput("mouse:click/double-click/wheel")
+	session.resize(120, 40)
+
+	// The default 120-column board has five 24-cell columns. Task C is the
+	// first card in the third rendered column.
+	checkpoint := session.checkpoint()
+	session.clickSGR(49, 2)
+	session.clickSGR(49, 2)
+	session.waitForOutputSince(checkpoint, "Task #3: Task C")
+
+	checkpoint = session.checkpoint()
+	session.clickX10(1, 39)
+	session.waitForOutputSince(checkpoint, "mouse:click/double-click/wheel")
+
+	// Back preserves the card selection, so keyboard Enter must reopen Task C.
+	checkpoint = session.checkpoint()
+	session.pressKeys("enter")
+	session.waitForOutputSince(checkpoint, "Task #3: Task C")
+	session.pressKeys("q", "q")
+	session.waitForExit()
+}
+
+func TestE2E_TUIMouse_WheelRevealsTaskAndScrollsLongDetail(t *testing.T) {
+	kanbanDir := initBoard(t)
+	mustCreateTask(t, kanbanDir, "Short first card", "--priority", "critical")
+	mustCreateTask(t, kanbanDir,
+		"A deliberately long second card title that wraps",
+		"--priority", "high")
+
+	var bodyLines []string
+	bodyLines = append(bodyLines, "DETAIL-TOP-MARKER")
+	for i := 1; i <= 45; i++ {
+		bodyLines = append(bodyLines, fmt.Sprintf("detail line %02d", i))
+	}
+	bodyLines = append(bodyLines, "DETAIL-BOTTOM-MARKER")
+	mustCreateTask(t, kanbanDir, "Newly revealed task",
+		"--priority", "medium",
+		"--body", strings.Join(bodyLines, "\n"))
+
+	session := startTUIProcessWithOptions(t, kanbanDir, tuiProcessOptions{
+		args: []string{"--mouse"},
+		cols: 100,
+		rows: 14,
+	})
+	session.waitForOutput("mouse:click/double-click/wheel")
+
+	checkpoint := session.checkpoint()
+	session.wheelSGR(1, 2, 1)
+	session.wheelSGR(2, 2, 1)
+	session.waitForOutputSince(checkpoint, "revealed task")
+
+	// After the two wheel events, the second card starts below the up
+	// indicator and the newly revealed third card begins at row 7.
+	checkpoint = session.checkpoint()
+	session.clickSGR(2, 8)
+	session.clickSGR(2, 8)
+	session.waitForOutputSince(checkpoint, "Task #3: Newly revealed task")
+
+	checkpoint = session.checkpoint()
+	for range 30 {
+		session.wheelSGR(2, 5, 1)
+	}
+	session.waitForOutputSince(checkpoint, "DETAIL-BOTTOM-MARKER")
+
+	// Extra wheel events remain clamped and the keyboard fallback still works.
+	for range 5 {
+		session.wheelSGR(2, 5, 1)
+	}
+	for range 30 {
+		session.wheelSGR(2, 5, -1)
+	}
+	checkpoint = session.checkpoint()
+	session.pressKeys("q")
+	session.waitForOutputSince(checkpoint, "mouse:click/double-click/wheel")
+	session.pressKeys("q")
+	session.waitForExit()
+}

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -85,6 +85,11 @@ type Board struct {
 	// are removed from the board view.
 	hideEmptyColumns bool
 	now              func() time.Time // clock for duration display; defaults to time.Now
+	mouseEnabled     bool
+	mouseNow         func() time.Time
+	layoutGeneration uint64
+	layout           layoutSnapshot
+	pointer          pointerState
 
 	// Sort state.
 	sortField   string // one of sortFields
@@ -131,6 +136,7 @@ func NewBoard(cfg *config.Config) *Board {
 	b := &Board{
 		cfg:              cfg,
 		now:              time.Now,
+		mouseNow:         time.Now,
 		hideEmptyColumns: cfg.TUI.HideEmptyColumns,
 		sortField:        "priority",
 		sortReverse:      true,
@@ -144,9 +150,23 @@ func (b *Board) SetNow(fn func() time.Time) {
 	b.now = fn
 }
 
+// SetMouseEnabled controls whether the board responds to mouse messages and
+// renders mouse-specific affordances. Bubble Tea mouse reporting must also be
+// enabled by the caller.
+func (b *Board) SetMouseEnabled(v bool) {
+	b.mouseEnabled = v
+	b.invalidatePointerState()
+}
+
+// SetMouseNow overrides the clock used for double-click detection.
+func (b *Board) SetMouseNow(fn func() time.Time) {
+	b.mouseNow = fn
+}
+
 // SetHideEmptyColumns controls whether empty status columns are shown.
 func (b *Board) SetHideEmptyColumns(v bool) {
 	b.hideEmptyColumns = v
+	b.invalidatePointerState()
 	b.loadTasks()
 }
 
@@ -159,19 +179,25 @@ func (b *Board) Init() tea.Cmd {
 func (b *Board) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		b.invalidatePointerState()
 		return b.handleKey(msg)
+	case tea.MouseMsg:
+		return b.handleMouse(tea.MouseEvent(msg))
 	case tea.WindowSizeMsg:
+		b.invalidatePointerState()
 		b.width = msg.Width
 		b.height = msg.Height
 		b.applyCreateInputLayout()
 		return b, nil
 	case ReloadMsg:
+		b.invalidatePointerState()
 		b.loadTasks()
 		b.refreshDetailTask()
 		return b, nil
 	case TickMsg:
 		return b, tickCmd()
 	case errMsg:
+		b.invalidatePointerState()
 		b.err = msg.err
 		return b, nil
 	}
@@ -182,6 +208,13 @@ func (b *Board) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (b *Board) View() string {
 	if b.width == 0 {
 		return "Loading..."
+	}
+
+	b.layout = layoutSnapshot{
+		generation: b.layoutGeneration,
+		width:      b.width,
+		height:     b.height,
+		view:       b.view,
 	}
 
 	switch b.view {
@@ -420,6 +453,7 @@ func (b *Board) handleEnter() {
 		b.detailTask = t
 		b.detailScrollOff = 0
 		b.view = viewDetail
+		b.invalidatePointerState()
 	}
 }
 
@@ -1328,8 +1362,9 @@ func (b *Board) viewBoard() string {
 
 	// Render columns.
 	renderedCols := make([]string, len(b.columns))
+	renderedTargets := make([][]cardTarget, len(b.columns))
 	for i, col := range b.columns {
-		renderedCols[i] = b.renderColumn(i, col, colWidth)
+		renderedCols[i], renderedTargets[i] = b.renderColumn(i, col, colWidth)
 	}
 
 	boardView := lipgloss.JoinHorizontal(lipgloss.Top, renderedCols...)
@@ -1347,6 +1382,7 @@ func (b *Board) viewBoard() string {
 			boardView += strings.Repeat("\n", targetHeight-actual)
 		}
 	}
+	b.captureBoardLayout(colWidth, targetHeight, renderedTargets)
 
 	bottom := b.renderStatusBar()
 	if b.view == viewSearch {
@@ -1380,7 +1416,7 @@ func (b *Board) columnWidth() int {
 	return w
 }
 
-func (b *Board) renderColumn(colIdx int, col column, width int) string {
+func (b *Board) renderColumn(colIdx int, col column, width int) (string, []cardTarget) {
 	// Header.
 	headerText := fmt.Sprintf("%s (%d)", col.status, len(col.tasks))
 	wip := b.cfg.WIPLimit(col.status)
@@ -1410,11 +1446,14 @@ func (b *Board) renderColumn(colIdx int, col column, width int) string {
 	}
 
 	parts := []string{header}
+	var targets []cardTarget
+	y := 1
 
 	// Show "↑ N more" indicator if scrolled down.
 	if start > 0 {
 		indicator := fmt.Sprintf("  ↑ %d more", start)
 		parts = append(parts, dimStyle.Width(width).Render(truncate(indicator, width)))
+		y++
 	}
 
 	// Render visible cards.
@@ -1425,6 +1464,14 @@ func (b *Board) renderColumn(colIdx int, col column, width int) string {
 			t := col.tasks[rowIdx]
 			active := colIdx == b.activeCol && rowIdx == b.activeRow
 			parts = append(parts, b.renderCard(t, active, width))
+			cardHeight := b.cardHeight(t, width)
+			targets = append(targets, cardTarget{
+				taskID: t.ID,
+				col:    colIdx,
+				row:    rowIdx,
+				rect:   rect{x0: 0, y0: y, x1: width, y1: y + cardHeight},
+			})
+			y += cardHeight
 		}
 	}
 
@@ -1435,7 +1482,7 @@ func (b *Board) renderColumn(colIdx int, col column, width int) string {
 		parts = append(parts, dimStyle.Width(width).Render(truncate(indicator, width)))
 	}
 
-	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+	return lipgloss.JoinVertical(lipgloss.Left, parts...), targets
 }
 
 func (b *Board) renderCard(t *task.Task, active bool, width int) string {
@@ -1655,6 +1702,9 @@ func (b *Board) renderStatusBar() string {
 	}
 	status := fmt.Sprintf(" %s | %d tasks%s | c:create e:edit m:move n/p:status +/-:priority d:del s:sort[%s%s] /:search ?:help q:quit",
 		b.cfg.Board.Name, total, filter, b.sortField, arrow)
+	if b.mouseEnabled {
+		status = " mouse:click/double-click/wheel |" + status
+	}
 	status = truncate(status, b.width)
 
 	if b.err != nil {
@@ -1702,7 +1752,23 @@ func (b *Board) viewDetail() string {
 		end = len(lines)
 	}
 
-	return strings.Join(lines[off:end], "\n") + "\n\n" + dimStyle.Render(hint)
+	visible := strings.Join(lines[off:end], "\n")
+	if !b.mouseEnabled {
+		return visible + "\n\n" + dimStyle.Render(hint)
+	}
+
+	hint = "← Back  " + hint
+	renderedLines := end - off
+	if renderedLines < viewHeight {
+		visible += strings.Repeat("\n", viewHeight-renderedLines)
+	}
+	backWidth := min(lipgloss.Width("← Back"), b.width)
+	if backWidth > 0 && b.height > 0 {
+		b.layout.back = &backTarget{
+			rect: rect{x0: 0, y0: b.height - 1, x1: backWidth, y1: b.height},
+		}
+	}
+	return visible + "\n\n" + dimStyle.Render(truncate(hint, b.width))
 }
 
 func detailLines(t *task.Task, width int) []string {
@@ -2021,6 +2087,12 @@ func (b *Board) viewHelp() string {
 		{"?", "Show this help"},
 		{"esc/q", "Quit"},
 		{"ctrl+c", "Force quit"},
+	}
+	if b.mouseEnabled {
+		help = append(help,
+			struct{ key, desc string }{"click", "Select task; double-click opens detail"},
+			struct{ key, desc string }{"wheel", "Move selection or scroll task detail"},
+		)
 	}
 
 	var lines []string

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -1,0 +1,393 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const (
+	doubleClickWindow = 500 * time.Millisecond
+	detailWheelStep   = 3
+	detailChrome      = 2 // blank separator + fixed hint
+)
+
+// rect is a zero-based, half-open terminal-cell rectangle.
+type rect struct {
+	x0 int
+	y0 int
+	x1 int
+	y1 int
+}
+
+func (r rect) contains(x, y int) bool {
+	return x >= r.x0 && x < r.x1 && y >= r.y0 && y < r.y1
+}
+
+func (r rect) empty() bool {
+	return r.x0 >= r.x1 || r.y0 >= r.y1
+}
+
+func (r rect) intersect(other rect) rect {
+	return rect{
+		x0: max(r.x0, other.x0),
+		y0: max(r.y0, other.y0),
+		x1: min(r.x1, other.x1),
+		y1: min(r.y1, other.y1),
+	}
+}
+
+func (r rect) translate(x, y int) rect {
+	return rect{x0: r.x0 + x, y0: r.y0 + y, x1: r.x1 + x, y1: r.y1 + y}
+}
+
+type cardTarget struct {
+	taskID int
+	col    int
+	row    int
+	rect   rect
+}
+
+type columnTarget struct {
+	col    int
+	status string
+	rect   rect
+}
+
+type backTarget struct {
+	rect rect
+}
+
+type layoutSnapshot struct {
+	generation uint64
+	width      int
+	height     int
+	view       view
+	cards      []cardTarget
+	columns    []columnTarget
+	back       *backTarget
+}
+
+type pointerTargetKind int
+
+const (
+	pointerTargetNone pointerTargetKind = iota
+	pointerTargetCard
+	pointerTargetBack
+)
+
+type pointerState struct {
+	pressed       bool
+	kind          pointerTargetKind
+	taskID        int
+	rect          rect
+	generation    uint64
+	lastClickID   int
+	lastClickTime time.Time
+}
+
+func (b *Board) invalidatePointerState() {
+	b.layoutGeneration++
+	b.layout = layoutSnapshot{}
+	b.pointer = pointerState{}
+}
+
+func (b *Board) clearGesture() {
+	b.pointer.pressed = false
+	b.pointer.kind = pointerTargetNone
+	b.pointer.taskID = 0
+	b.pointer.rect = rect{}
+	b.pointer.generation = 0
+}
+
+func (b *Board) clearPendingClick() {
+	b.pointer.lastClickID = 0
+	b.pointer.lastClickTime = time.Time{}
+}
+
+func (b *Board) captureBoardLayout(colWidth, targetHeight int, targets [][]cardTarget) {
+	if !b.mouseEnabled || b.view != viewBoard || b.width <= 0 || targetHeight <= 0 {
+		return
+	}
+
+	screen := rect{x0: 0, y0: 0, x1: b.width, y1: min(targetHeight, b.height)}
+	if screen.empty() {
+		return
+	}
+
+	for colIdx, col := range b.columns {
+		x := colIdx * colWidth
+		colRect := rect{x0: x, y0: 0, x1: x + colWidth, y1: targetHeight}.intersect(screen)
+		if colRect.empty() {
+			continue
+		}
+		b.layout.columns = append(b.layout.columns, columnTarget{
+			col:    colIdx,
+			status: col.status,
+			rect:   colRect,
+		})
+		for _, target := range targets[colIdx] {
+			target.rect = target.rect.translate(x, 0).intersect(screen)
+			if !target.rect.empty() {
+				b.layout.cards = append(b.layout.cards, target)
+			}
+		}
+	}
+}
+
+func (b *Board) handleMouse(msg tea.MouseEvent) (tea.Model, tea.Cmd) {
+	if !b.mouseEnabled || msg.Shift || msg.Alt || msg.Ctrl {
+		b.clearGesture()
+		if msg.Shift || msg.Alt || msg.Ctrl {
+			b.clearPendingClick()
+		}
+		return b, nil
+	}
+
+	switch b.view {
+	case viewBoard:
+		return b.handleBoardMouse(msg)
+	case viewDetail:
+		return b.handleDetailMouse(msg)
+	default:
+		b.clearGesture()
+		return b, nil
+	}
+}
+
+func (b *Board) handleBoardMouse(msg tea.MouseEvent) (tea.Model, tea.Cmd) {
+	if msg.IsWheel() {
+		b.clearGesture()
+		b.clearPendingClick()
+		if isVerticalWheel(msg.Button) {
+			b.handleBoardWheel(msg)
+		}
+		return b, nil
+	}
+
+	switch msg.Action {
+	case tea.MouseActionPress:
+		if msg.Button != tea.MouseButtonLeft {
+			b.clearGesture()
+			b.clearPendingClick()
+			return b, nil
+		}
+		if target := b.cardAt(msg.X, msg.Y); target != nil {
+			b.pointer.pressed = true
+			b.pointer.kind = pointerTargetCard
+			b.pointer.taskID = target.taskID
+			b.pointer.rect = target.rect
+			b.pointer.generation = b.layout.generation
+		} else {
+			b.clearGesture()
+			b.clearPendingClick()
+		}
+	case tea.MouseActionMotion:
+		if b.pointer.pressed && !b.pointer.rect.contains(msg.X, msg.Y) {
+			b.clearGesture()
+			b.clearPendingClick()
+		}
+	case tea.MouseActionRelease:
+		if msg.Button != tea.MouseButtonLeft && msg.Button != tea.MouseButtonNone {
+			b.clearGesture()
+			b.clearPendingClick()
+			return b, nil
+		}
+		b.releaseBoardClick(msg.X, msg.Y)
+	}
+
+	return b, nil
+}
+
+func (b *Board) releaseBoardClick(x, y int) {
+	if !b.pointer.pressed ||
+		b.pointer.kind != pointerTargetCard ||
+		b.pointer.generation != b.layout.generation ||
+		b.layout.generation != b.layoutGeneration ||
+		!b.pointer.rect.contains(x, y) {
+		b.clearGesture()
+		return
+	}
+
+	taskID := b.pointer.taskID
+	b.clearGesture()
+	if !b.selectTask(taskID) {
+		b.clearPendingClick()
+		return
+	}
+
+	now := b.mouseNow()
+	if b.pointer.lastClickID == taskID &&
+		!b.pointer.lastClickTime.IsZero() &&
+		now.Sub(b.pointer.lastClickTime) >= 0 &&
+		now.Sub(b.pointer.lastClickTime) <= doubleClickWindow {
+		b.clearPendingClick()
+		b.handleEnter()
+		return
+	}
+
+	b.pointer.lastClickID = taskID
+	b.pointer.lastClickTime = now
+}
+
+func (b *Board) handleDetailMouse(msg tea.MouseEvent) (tea.Model, tea.Cmd) {
+	if msg.IsWheel() {
+		b.clearGesture()
+		b.clearPendingClick()
+		if isVerticalWheel(msg.Button) {
+			b.handleDetailWheel(msg.Button)
+		}
+		return b, nil
+	}
+
+	switch msg.Action {
+	case tea.MouseActionPress:
+		b.handleDetailPress(msg)
+	case tea.MouseActionMotion:
+		if b.pointer.pressed && !b.pointer.rect.contains(msg.X, msg.Y) {
+			b.clearGesture()
+		}
+	case tea.MouseActionRelease:
+		b.handleDetailRelease(msg)
+	}
+
+	return b, nil
+}
+
+func (b *Board) handleDetailWheel(button tea.MouseButton) {
+	switch button {
+	case tea.MouseButtonWheelUp:
+		b.detailScrollOff -= detailWheelStep
+		if b.detailScrollOff < 0 {
+			b.detailScrollOff = 0
+		}
+	case tea.MouseButtonWheelDown:
+		b.detailScrollOff += detailWheelStep
+		b.clampDetailScroll()
+	}
+}
+
+func (b *Board) handleDetailPress(msg tea.MouseEvent) {
+	if msg.Button != tea.MouseButtonLeft {
+		b.clearGesture()
+		b.clearPendingClick()
+		return
+	}
+	if b.layout.back != nil && b.layout.back.rect.contains(msg.X, msg.Y) {
+		b.pointer.pressed = true
+		b.pointer.kind = pointerTargetBack
+		b.pointer.rect = b.layout.back.rect
+		b.pointer.generation = b.layout.generation
+		return
+	}
+	b.clearGesture()
+	b.clearPendingClick()
+}
+
+func (b *Board) handleDetailRelease(msg tea.MouseEvent) {
+	if msg.Button != tea.MouseButtonLeft && msg.Button != tea.MouseButtonNone {
+		b.clearGesture()
+		return
+	}
+	if b.pointer.pressed &&
+		b.pointer.kind == pointerTargetBack &&
+		b.pointer.generation == b.layout.generation &&
+		b.layout.generation == b.layoutGeneration &&
+		b.pointer.rect.contains(msg.X, msg.Y) {
+		b.view = viewBoard
+		b.detailTask = nil
+		b.detailScrollOff = 0
+		b.invalidatePointerState()
+		return
+	}
+	b.clearGesture()
+}
+
+func isVerticalWheel(button tea.MouseButton) bool {
+	return button == tea.MouseButtonWheelUp || button == tea.MouseButtonWheelDown
+}
+
+func (b *Board) handleBoardWheel(msg tea.MouseEvent) {
+	target := b.columnAt(msg.X, msg.Y)
+	if target == nil {
+		return
+	}
+
+	b.activeCol = target.col
+	b.clampRow()
+	col := b.currentColumn()
+	if col == nil || len(col.tasks) == 0 {
+		return
+	}
+
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		if b.activeRow > 0 {
+			b.activeRow--
+		}
+	case tea.MouseButtonWheelDown:
+		if b.activeRow < len(col.tasks)-1 {
+			b.activeRow++
+		}
+	default:
+		return
+	}
+	b.ensureVisible()
+}
+
+func (b *Board) cardAt(x, y int) *cardTarget {
+	if b.layout.generation != b.layoutGeneration || b.layout.view != viewBoard {
+		return nil
+	}
+	for i := range b.layout.cards {
+		if b.layout.cards[i].rect.contains(x, y) {
+			return &b.layout.cards[i]
+		}
+	}
+	return nil
+}
+
+func (b *Board) columnAt(x, y int) *columnTarget {
+	if b.layout.generation != b.layoutGeneration || b.layout.view != viewBoard {
+		return nil
+	}
+	for i := range b.layout.columns {
+		if b.layout.columns[i].rect.contains(x, y) {
+			return &b.layout.columns[i]
+		}
+	}
+	return nil
+}
+
+func (b *Board) selectTask(id int) bool {
+	for colIdx := range b.columns {
+		for rowIdx, t := range b.columns[colIdx].tasks {
+			if t.ID == id {
+				b.activeCol = colIdx
+				b.activeRow = rowIdx
+				b.ensureVisible()
+				return true
+			}
+		}
+	}
+	b.clampRow()
+	return false
+}
+
+func (b *Board) clampDetailScroll() {
+	if b.detailTask == nil {
+		b.detailScrollOff = 0
+		return
+	}
+	viewHeight := b.height - detailChrome
+	if viewHeight < 1 {
+		viewHeight = len(detailLines(b.detailTask, b.width))
+	}
+	maxOff := len(detailLines(b.detailTask, b.width)) - viewHeight
+	if maxOff < 0 {
+		maxOff = 0
+	}
+	if b.detailScrollOff > maxOff {
+		b.detailScrollOff = maxOff
+	}
+}

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -1,0 +1,706 @@
+package tui
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/antopolskiy/kanban-md/internal/config"
+	"github.com/antopolskiy/kanban-md/internal/task"
+)
+
+var mouseTestTime = time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC) //nolint:gochecknoglobals // fixed test clock
+
+func newMouseTestBoard() *Board {
+	cfg := config.NewDefault("Mouse Test")
+	tasks := []*task.Task{
+		{ID: 1, Title: "Task A", Status: "backlog", Priority: "high", Updated: mouseTestTime},
+		{ID: 2, Title: "Task B with a longer title", Status: "backlog", Priority: "medium", Updated: mouseTestTime},
+		{ID: 3, Title: "Task C", Status: "in-progress", Priority: "high", Updated: mouseTestTime},
+		{ID: 4, Title: "Task D", Status: "done", Priority: "low", Updated: mouseTestTime},
+	}
+	b := &Board{
+		cfg:          cfg,
+		tasks:        tasks,
+		columns:      columnsForTasks(cfg.BoardStatuses(), tasks),
+		width:        120,
+		height:       40,
+		now:          func() time.Time { return mouseTestTime.Add(time.Hour) },
+		mouseNow:     func() time.Time { return mouseTestTime },
+		mouseEnabled: true,
+		sortField:    "priority",
+		sortReverse:  true,
+	}
+	_ = b.View()
+	return b
+}
+
+func columnsForTasks(statuses []string, tasks []*task.Task) []column {
+	columns := make([]column, len(statuses))
+	for i, status := range statuses {
+		columns[i].status = status
+		for _, tk := range tasks {
+			if tk.Status == status {
+				columns[i].tasks = append(columns[i].tasks, tk)
+			}
+		}
+	}
+	return columns
+}
+
+func clickTarget(b *Board, target cardTarget, releaseButton tea.MouseButton) {
+	x := target.rect.x0
+	y := target.rect.y0
+	_, _ = b.Update(tea.MouseMsg{
+		X: x, Y: y, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: x, Y: y, Button: releaseButton, Action: tea.MouseActionRelease,
+	})
+}
+
+func targetForTask(t *testing.T, b *Board, taskID int) cardTarget {
+	t.Helper()
+	_ = b.View()
+	for _, target := range b.layout.cards {
+		if target.taskID == taskID {
+			return target
+		}
+	}
+	t.Fatalf("task #%d has no visible mouse target: %#v", taskID, b.layout.cards)
+	return cardTarget{}
+}
+
+func TestMouseClickSelectsAndDoubleClickOpensDetail(t *testing.T) {
+	b := newMouseTestBoard()
+	now := mouseTestTime
+	b.SetMouseNow(func() time.Time { return now })
+	target := targetForTask(t, b, 3)
+
+	clickTarget(b, target, tea.MouseButtonLeft)
+	if b.view != viewBoard {
+		t.Fatalf("single click changed view to %v", b.view)
+	}
+	if got := b.selectedTask(); got == nil || got.ID != 3 {
+		t.Fatalf("single click selected %#v, want task #3", got)
+	}
+
+	now = now.Add(doubleClickWindow)
+	target = targetForTask(t, b, 3)
+	clickTarget(b, target, tea.MouseButtonLeft)
+	if b.view != viewDetail || b.detailTask == nil || b.detailTask.ID != 3 {
+		t.Fatalf("double-click did not open task #3 detail: view=%v task=%#v", b.view, b.detailTask)
+	}
+}
+
+func TestMouseDoubleClickExpiresAfter500Milliseconds(t *testing.T) {
+	b := newMouseTestBoard()
+	now := mouseTestTime
+	b.SetMouseNow(func() time.Time { return now })
+	target := targetForTask(t, b, 2)
+
+	clickTarget(b, target, tea.MouseButtonLeft)
+	now = now.Add(doubleClickWindow + time.Millisecond)
+	target = targetForTask(t, b, 2)
+	clickTarget(b, target, tea.MouseButtonLeft)
+
+	if b.view != viewBoard {
+		t.Fatalf("expired double-click opened view %v", b.view)
+	}
+	if b.pointer.lastClickID != 2 {
+		t.Fatalf("expired click should start a new sequence, lastClickID=%d", b.pointer.lastClickID)
+	}
+}
+
+func TestMouseOutsideClickBreaksDoubleClickSequence(t *testing.T) {
+	b := newMouseTestBoard()
+	target := targetForTask(t, b, 2)
+	clickTarget(b, target, tea.MouseButtonLeft)
+
+	_, _ = b.Update(tea.MouseMsg{
+		X: 1, Y: 0, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: 1, Y: 0, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease,
+	})
+
+	target = targetForTask(t, b, 2)
+	clickTarget(b, target, tea.MouseButtonLeft)
+	if b.view != viewBoard {
+		t.Fatalf("click after an outside click opened view %v", b.view)
+	}
+}
+
+func TestMouseAcceptsSGRAndX10Releases(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		releaseButton tea.MouseButton
+	}{
+		{name: "SGR left-button release", releaseButton: tea.MouseButtonLeft},
+		{name: "X10 buttonless release", releaseButton: tea.MouseButtonNone},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newMouseTestBoard()
+			clickTarget(b, targetForTask(t, b, 2), tt.releaseButton)
+			if got := b.selectedTask(); got == nil || got.ID != 2 {
+				t.Fatalf("selected task = %#v, want #2", got)
+			}
+		})
+	}
+}
+
+func TestMouseBackIsSingleClick(t *testing.T) {
+	b := newMouseTestBoard()
+	b.selectTask(3)
+	b.handleEnter()
+	_ = b.View()
+	if b.layout.back == nil {
+		t.Fatal("mouse detail view has no Back target")
+	}
+
+	target := b.layout.back.rect
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.x0, Y: target.y0, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.x0, Y: target.y0, Button: tea.MouseButtonNone, Action: tea.MouseActionRelease,
+	})
+
+	if b.view != viewBoard || b.detailTask != nil {
+		t.Fatalf("Back click left view=%v task=%#v", b.view, b.detailTask)
+	}
+	if got := b.selectedTask(); got == nil || got.ID != 3 {
+		t.Fatalf("Back click lost keyboard selection: %#v", got)
+	}
+}
+
+func TestMouseWheelRoutesByHoveredColumnAndClamps(t *testing.T) {
+	b := newMouseTestBoard()
+	backlog := b.layout.columns[0]
+
+	_, _ = b.Update(tea.MouseMsg{
+		X: backlog.rect.x0, Y: backlog.rect.y0,
+		Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress,
+	})
+	if b.activeCol != 0 || b.activeRow != 1 {
+		t.Fatalf("wheel down selected col=%d row=%d, want 0/1", b.activeCol, b.activeRow)
+	}
+
+	_, _ = b.Update(tea.MouseMsg{
+		X: backlog.rect.x0, Y: backlog.rect.y0,
+		Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress,
+	})
+	if b.activeRow != 1 {
+		t.Fatalf("wheel moved beyond bottom boundary to row %d", b.activeRow)
+	}
+
+	_, _ = b.Update(tea.MouseMsg{
+		X: backlog.rect.x0, Y: backlog.rect.y0,
+		Button: tea.MouseButtonWheelUp, Action: tea.MouseActionPress,
+	})
+	if b.activeRow != 0 {
+		t.Fatalf("wheel up selected row=%d, want 0", b.activeRow)
+	}
+
+	inProgress := b.layout.columns[2]
+	_, _ = b.Update(tea.MouseMsg{
+		X: inProgress.rect.x0, Y: inProgress.rect.y0,
+		Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress,
+	})
+	if b.activeCol != 2 || b.activeRow != 0 {
+		t.Fatalf("hovered wheel selected col=%d row=%d, want 2/0", b.activeCol, b.activeRow)
+	}
+}
+
+func TestMouseWheelScrollsDetailThreeLinesAndClamps(t *testing.T) {
+	b := newMouseTestBoard()
+	b.tasks[0].Body = strings.Repeat("body line\n", 60)
+	b.columns[0].tasks[0] = b.tasks[0]
+	b.detailTask = b.tasks[0]
+	b.view = viewDetail
+	_ = b.View()
+
+	_, _ = b.Update(tea.MouseMsg{
+		X: 10, Y: 10, Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress,
+	})
+	if b.detailScrollOff != detailWheelStep {
+		t.Fatalf("detail offset=%d, want %d", b.detailScrollOff, detailWheelStep)
+	}
+
+	for range 100 {
+		_, _ = b.Update(tea.MouseMsg{
+			X: 10, Y: 10, Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress,
+		})
+	}
+	maxOff := len(detailLines(b.detailTask, b.width)) - (b.height - 2)
+	if b.detailScrollOff != maxOff {
+		t.Fatalf("detail bottom offset=%d, want %d", b.detailScrollOff, maxOff)
+	}
+
+	for range 100 {
+		_, _ = b.Update(tea.MouseMsg{
+			X: 10, Y: 10, Button: tea.MouseButtonWheelUp, Action: tea.MouseActionPress,
+		})
+	}
+	if b.detailScrollOff != 0 {
+		t.Fatalf("detail top offset=%d, want 0", b.detailScrollOff)
+	}
+}
+
+func TestMouseIgnoresButtonsModifiersAndInactiveViews(t *testing.T) {
+	tests := []tea.MouseMsg{
+		{X: 1, Y: 1, Button: tea.MouseButtonRight, Action: tea.MouseActionPress},
+		{X: 1, Y: 1, Button: tea.MouseButtonMiddle, Action: tea.MouseActionPress},
+		{X: 1, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress, Shift: true},
+		{X: 1, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress, Alt: true},
+		{X: 1, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress, Ctrl: true},
+		{X: 1, Y: 1, Button: tea.MouseButtonWheelLeft, Action: tea.MouseActionPress},
+	}
+	for _, msg := range tests {
+		b := newMouseTestBoard()
+		_, _ = b.Update(msg)
+		if got := b.selectedTask(); got == nil || got.ID != 1 {
+			t.Fatalf("message %s changed selection to %#v", msg.String(), got)
+		}
+		if b.pointer.pressed {
+			t.Fatalf("message %s started a gesture", msg.String())
+		}
+	}
+
+	for _, inactiveView := range []view{
+		viewMove, viewConfirmDelete, viewHelp, viewCreate, viewDebug, viewSearch,
+	} {
+		b := newMouseTestBoard()
+		b.view = inactiveView
+		_ = b.View()
+		_, _ = b.Update(tea.MouseMsg{
+			X: 1, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+		})
+		if b.pointer.pressed {
+			t.Fatalf("view %v accepted mouse input", inactiveView)
+		}
+	}
+}
+
+func TestMousePendingClickInvalidatedByKeyboardResizeAndReload(t *testing.T) {
+	tests := []struct {
+		name       string
+		invalidate tea.Msg
+	}{
+		{name: "keyboard", invalidate: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")}},
+		{name: "sort", invalidate: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")}},
+		{name: "search", invalidate: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")}},
+		{name: "view change", invalidate: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")}},
+		{name: "resize", invalidate: tea.WindowSizeMsg{Width: 100, Height: 30}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newMouseTestBoard()
+			clickTarget(b, targetForTask(t, b, 1), tea.MouseButtonLeft)
+			if b.pointer.lastClickID != 1 {
+				t.Fatal("first click was not recorded")
+			}
+
+			_, _ = b.Update(tt.invalidate)
+			if b.pointer.lastClickID != 0 || b.pointer.pressed {
+				t.Fatalf("%s did not clear pointer state: %#v", tt.name, b.pointer)
+			}
+		})
+	}
+}
+
+func TestMousePendingClickInvalidatedByWheelAndReload(t *testing.T) {
+	b := newMouseFilesystemBoard(t)
+	clickTarget(b, targetForTask(t, b, 1), tea.MouseButtonLeft)
+	col := b.layout.columns[0]
+	_, _ = b.Update(tea.MouseMsg{
+		X: col.rect.x0, Y: col.rect.y0,
+		Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress,
+	})
+	if b.pointer.lastClickID != 0 {
+		t.Fatalf("wheel did not clear pending click: %#v", b.pointer)
+	}
+
+	clickTarget(b, targetForTask(t, b, 1), tea.MouseButtonLeft)
+	_, _ = b.Update(ReloadMsg{})
+	if b.pointer.lastClickID != 0 || b.pointer.pressed {
+		t.Fatalf("reload did not clear pointer state: %#v", b.pointer)
+	}
+}
+
+func newMouseFilesystemBoard(t *testing.T) *Board {
+	t.Helper()
+	kanbanDir := filepath.Join(t.TempDir(), "kanban")
+	if err := os.MkdirAll(filepath.Join(kanbanDir, "tasks"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.NewDefault("Mouse Filesystem Test")
+	cfg.SetDir(kanbanDir)
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	tk := &task.Task{
+		ID: 1, Title: "Task A", Status: "backlog", Priority: "high", Updated: mouseTestTime,
+	}
+	path := filepath.Join(cfg.TasksPath(), task.GenerateFilename(tk.ID, tk.Title))
+	if err := task.Write(path, tk); err != nil {
+		t.Fatal(err)
+	}
+	b := NewBoard(cfg)
+	b.SetMouseEnabled(true)
+	b.SetMouseNow(func() time.Time { return mouseTestTime })
+	b.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	_ = b.View()
+	return b
+}
+
+func TestMouseReleaseAfterMotionOutsideCardCancels(t *testing.T) {
+	b := newMouseTestBoard()
+	target := targetForTask(t, b, 2)
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x0, Y: target.rect.y0,
+		Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x1 + 1, Y: target.rect.y1 + 1,
+		Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x0, Y: target.rect.y0,
+		Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease,
+	})
+	if got := b.selectedTask(); got == nil || got.ID != 1 {
+		t.Fatalf("canceled gesture selected %#v, want original #1", got)
+	}
+}
+
+func TestMouseEdgeBranches(t *testing.T) {
+	b := newMouseTestBoard()
+	target := targetForTask(t, b, 1)
+
+	// Presses outside cards and releases without a matching press are ignored.
+	_, _ = b.Update(tea.MouseMsg{
+		X: 1, Y: 0, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x0, Y: target.rect.y0,
+		Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease,
+	})
+	if b.pointer.pressed {
+		t.Fatal("outside press started a gesture")
+	}
+
+	// Motion within the card keeps the gesture; an unrelated release cancels it.
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x0, Y: target.rect.y0,
+		Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x0 + 1, Y: target.rect.y0 + 1,
+		Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion,
+	})
+	if !b.pointer.pressed {
+		t.Fatal("motion within target canceled gesture")
+	}
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x0 + 1, Y: target.rect.y0 + 1,
+		Button: tea.MouseButtonRight, Action: tea.MouseActionRelease,
+	})
+	if b.pointer.pressed {
+		t.Fatal("different-button release did not cancel gesture")
+	}
+
+	// A stale layout generation cannot complete a click.
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x0, Y: target.rect.y0,
+		Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	b.layoutGeneration++
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x0, Y: target.rect.y0,
+		Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease,
+	})
+	if b.pointer.lastClickID != 0 {
+		t.Fatal("stale layout completed a click")
+	}
+
+	if b.cardAt(-1, -1) != nil || b.columnAt(-1, -1) != nil {
+		t.Fatal("off-screen coordinate returned a target")
+	}
+	if b.selectTask(999) {
+		t.Fatal("missing task was selected")
+	}
+
+	// Disabled boards ignore mouse messages entirely.
+	b.SetMouseEnabled(false)
+	_, _ = b.Update(tea.MouseMsg{
+		X: target.rect.x0, Y: target.rect.y0,
+		Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	if b.pointer.pressed {
+		t.Fatal("disabled mouse mode accepted a press")
+	}
+}
+
+func TestMouseDetailEdgeBranches(t *testing.T) {
+	b := newMouseTestBoard()
+	b.detailTask = b.tasks[0]
+	b.view = viewDetail
+	_ = b.View()
+
+	// Non-left presses, outside presses, outside motion, and unrelated releases
+	// must not activate Back.
+	_, _ = b.Update(tea.MouseMsg{
+		X: 0, Y: b.height - 1, Button: tea.MouseButtonRight, Action: tea.MouseActionPress,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: 10, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	if b.pointer.pressed {
+		t.Fatal("detail content started a Back gesture")
+	}
+	back := b.layout.back.rect
+	_, _ = b.Update(tea.MouseMsg{
+		X: back.x0, Y: back.y0, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: back.x1 + 1, Y: back.y0, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion,
+	})
+	_, _ = b.Update(tea.MouseMsg{
+		X: back.x0, Y: back.y0, Button: tea.MouseButtonRight, Action: tea.MouseActionRelease,
+	})
+	if b.view != viewDetail {
+		t.Fatal("canceled Back gesture changed the view")
+	}
+
+	b.detailTask = nil
+	b.detailScrollOff = 99
+	b.clampDetailScroll()
+	if b.detailScrollOff != 0 {
+		t.Fatalf("nil detail task offset=%d, want 0", b.detailScrollOff)
+	}
+
+	b.detailTask = b.tasks[0]
+	b.height = 1
+	b.detailScrollOff = 99
+	b.clampDetailScroll()
+	if b.detailScrollOff != 0 {
+		t.Fatalf("short detail viewport offset=%d, want 0", b.detailScrollOff)
+	}
+}
+
+func TestMouseLayoutUnavailableUntilRendered(t *testing.T) {
+	b := newMouseTestBoard()
+	b.invalidatePointerState()
+	if b.cardAt(1, 1) != nil || b.columnAt(1, 1) != nil {
+		t.Fatal("invalidated layout returned targets")
+	}
+
+	b.view = viewHelp
+	_ = b.View()
+	if b.cardAt(1, 1) != nil || b.columnAt(1, 1) != nil {
+		t.Fatal("non-board view returned board targets")
+	}
+
+	b.view = viewBoard
+	b.width = 0
+	b.layout = layoutSnapshot{}
+	b.captureBoardLayout(10, 10, nil)
+	if len(b.layout.columns) != 0 {
+		t.Fatal("zero-width board captured columns")
+	}
+}
+
+func TestSetHideEmptyColumnsInvalidatesMouseState(t *testing.T) {
+	b := newMouseFilesystemBoard(t)
+	clickTarget(b, targetForTask(t, b, 1), tea.MouseButtonLeft)
+	b.SetHideEmptyColumns(true)
+	if b.pointer.lastClickID != 0 || b.pointer.pressed {
+		t.Fatalf("hide-empty change did not invalidate pointer state: %#v", b.pointer)
+	}
+}
+
+func TestMouseLayoutProperties(t *testing.T) {
+	for _, titleLines := range []int{1, 2, 3} {
+		for _, width := range []int{1, 4, 8, 9, 39, 40, 79, 80, 121, 300} {
+			for _, height := range []int{1, 2, 3, 4, 8, 19, 40} {
+				t.Run(fmt.Sprintf("title_%d/%dx%d", titleLines, width, height), func(t *testing.T) {
+					b := newMouseTestBoard()
+					b.cfg.TUI.TitleLines = titleLines
+					b.width = width
+					b.height = height
+					if height%2 == 0 {
+						b.err = errors.New("visible error chrome")
+					}
+					b.columns[0].tasks[1].Title = "日本語の長いタイトル with mixed widths"
+					_ = b.View()
+					assertValidMouseLayout(t, b)
+				})
+			}
+		}
+	}
+}
+
+func TestMouseLayoutAccountsForScrollIndicatorsAndVisibleEmptyColumns(t *testing.T) {
+	b := newMouseTestBoard()
+	b.columns[0].scrollOff = 1
+	b.columns = b.columns[:3] // hidden and archived columns are not rendered targets
+	_ = b.View()
+
+	target := targetForTask(t, b, 2)
+	if target.rect.y0 != 2 {
+		t.Fatalf("scrolled card starts at y=%d, want 2 after header and up indicator", target.rect.y0)
+	}
+	if len(b.layout.columns) != 3 {
+		t.Fatalf("rendered column targets=%d, want 3", len(b.layout.columns))
+	}
+	if b.layout.columns[1].status != "todo" {
+		t.Fatalf("empty rendered column status=%q, want todo", b.layout.columns[1].status)
+	}
+	for _, card := range b.layout.cards {
+		if card.col == 1 {
+			t.Fatalf("empty column unexpectedly has card target %#v", card)
+		}
+	}
+}
+
+func TestMouseLayoutClipsUnusedRightSideAndBottomChrome(t *testing.T) {
+	b := newMouseTestBoard()
+	b.width = 300 // columns cap at 50, leaving unused right-side space
+	b.height = 12
+	b.err = errors.New("error")
+	_ = b.View()
+	assertValidMouseLayout(t, b)
+
+	last := b.layout.columns[len(b.layout.columns)-1]
+	if last.rect.x1 != len(b.columns)*50 {
+		t.Fatalf("last column ends at x=%d, want %d", last.rect.x1, len(b.columns)*50)
+	}
+	if b.columnAt(299, 1) != nil {
+		t.Fatal("unused right-side space was treated as a column")
+	}
+	if b.columnAt(1, b.height-b.chromeHeight()) != nil {
+		t.Fatal("bottom chrome was treated as a column")
+	}
+}
+
+func TestMouseLayoutUnicodeCardHeightMatchesTarget(t *testing.T) {
+	b := newMouseTestBoard()
+	b.cfg.TUI.TitleLines = 3
+	b.columns[0].tasks[0].Title = "日本語のタイトル 日本語のタイトル"
+	b.width = 40
+	_ = b.View()
+
+	target := targetForTask(t, b, 1)
+	want := b.cardHeight(b.columns[0].tasks[0], b.columnWidth())
+	if got := target.rect.y1 - target.rect.y0; got != want {
+		t.Fatalf("Unicode card target height=%d, want rendered height %d", got, want)
+	}
+}
+
+func assertValidMouseLayout(t testing.TB, b *Board) {
+	t.Helper()
+	screen := rect{x0: 0, y0: 0, x1: max(0, b.width), y1: max(0, b.height-b.chromeHeight())}
+
+	for i, col := range b.layout.columns {
+		if col.rect.empty() {
+			t.Fatalf("column %d has empty rect %#v", i, col.rect)
+		}
+		if col.rect != col.rect.intersect(screen) {
+			t.Fatalf("column %d escapes screen: rect=%#v screen=%#v", i, col.rect, screen)
+		}
+		for j := i + 1; j < len(b.layout.columns); j++ {
+			if rectsOverlap(col.rect, b.layout.columns[j].rect) {
+				t.Fatalf("columns %d and %d overlap: %#v %#v", i, j, col.rect, b.layout.columns[j].rect)
+			}
+		}
+	}
+
+	for i, card := range b.layout.cards {
+		if card.rect.empty() {
+			t.Fatalf("card %d has empty rect %#v", card.taskID, card.rect)
+		}
+		if card.rect != card.rect.intersect(screen) {
+			t.Fatalf("card %d escapes screen: rect=%#v screen=%#v", card.taskID, card.rect, screen)
+		}
+		var containing int
+		for _, col := range b.layout.columns {
+			if card.rect == card.rect.intersect(col.rect) {
+				containing++
+			}
+		}
+		if containing != 1 {
+			t.Fatalf("card %d belongs to %d rendered columns", card.taskID, containing)
+		}
+		for j := i + 1; j < len(b.layout.cards); j++ {
+			if card.col == b.layout.cards[j].col && rectsOverlap(card.rect, b.layout.cards[j].rect) {
+				t.Fatalf("cards %d and %d overlap: %#v %#v",
+					card.taskID, b.layout.cards[j].taskID, card.rect, b.layout.cards[j].rect)
+			}
+		}
+	}
+}
+
+func rectsOverlap(a, b rect) bool {
+	return a.x0 < b.x1 && b.x0 < a.x1 && a.y0 < b.y1 && b.y0 < a.y1
+}
+
+func FuzzMouseLayout(f *testing.F) {
+	f.Add(120, 40, 2, 6, 0, false)
+	f.Add(1, 1, 1, 1, 0, true)
+	f.Add(300, 8, 3, 24, 10, false)
+	f.Fuzz(func(t *testing.T, width, height, titleLines, taskCount, scrollOff int, withError bool) {
+		width = fuzzRange(width, 1, 400)
+		height = fuzzRange(height, 1, 100)
+		titleLines = fuzzRange(titleLines, 1, 3)
+		taskCount = fuzzRange(taskCount, 0, 50)
+
+		cfg := config.NewDefault("Fuzz")
+		cfg.TUI.TitleLines = titleLines
+		tasks := make([]*task.Task, taskCount)
+		for i := range taskCount {
+			tasks[i] = &task.Task{
+				ID:       i + 1,
+				Title:    strings.Repeat("日本語 mixed title ", i%7+1),
+				Status:   cfg.BoardStatuses()[i%len(cfg.BoardStatuses())],
+				Priority: cfg.Priorities[i%len(cfg.Priorities)],
+				Updated:  mouseTestTime,
+			}
+		}
+		b := &Board{
+			cfg:          cfg,
+			tasks:        tasks,
+			columns:      columnsForTasks(cfg.BoardStatuses(), tasks),
+			width:        width,
+			height:       height,
+			now:          func() time.Time { return mouseTestTime },
+			mouseNow:     func() time.Time { return mouseTestTime },
+			mouseEnabled: true,
+			sortField:    "priority",
+		}
+		if len(b.columns) > 0 && len(b.columns[0].tasks) > 0 {
+			b.columns[0].scrollOff = fuzzRange(scrollOff, 0, len(b.columns[0].tasks)-1)
+		}
+		if withError {
+			b.err = errors.New("fuzz error chrome")
+		}
+		_ = b.View()
+		assertValidMouseLayout(t, b)
+	})
+}
+
+func fuzzRange(v, low, high int) int {
+	if high <= low {
+		return low
+	}
+	if v < 0 {
+		v = -v
+	}
+	return low + v%(high-low+1)
+}

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,6 +80,35 @@ func TestSnapshot_HelpView(t *testing.T) {
 	b, _ := setupTestBoard(t)
 	b = sendKey(b, "?") // open help
 	assertGolden(t, "help_view", b.View())
+}
+
+func TestSnapshot_MouseHelpView(t *testing.T) {
+	b, _ := setupTestBoard(t)
+	b.SetMouseEnabled(true)
+	b = sendKey(b, "?") // open help
+	assertGolden(t, "mouse_help_view", b.View())
+}
+
+func TestSnapshot_MouseDetailBackAffordance(t *testing.T) {
+	b, _ := setupTestBoard(t)
+	b.SetMouseEnabled(true)
+	b = sendKey(b, "enter")
+	assertGolden(t, "mouse_detail_back", b.View())
+}
+
+func TestSnapshot_MouseNarrowTerminal(t *testing.T) {
+	b, _ := setupTestBoard(t)
+	b.SetMouseEnabled(true)
+	b.Update(tea.WindowSizeMsg{Width: 20, Height: 10})
+	assertGolden(t, "mouse_narrow", trimSnapshotLineEnds(b.View()))
+}
+
+func trimSnapshotLineEnds(value string) string {
+	lines := strings.Split(value, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " ")
+	}
+	return strings.Join(lines, "\n")
 }
 
 func TestSnapshot_SearchActive(t *testing.T) {

--- a/internal/tui/testdata/mouse_detail_back.golden
+++ b/internal/tui/testdata/mouse_detail_back.golden
@@ -1,0 +1,40 @@
+Task #1: Task A
+───────────────
+
+Status:         backlog
+Priority:       high
+Created:        0001-01-01 00:00
+Updated:        2026-01-15 10:00
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+← Back  q/esc:back

--- a/internal/tui/testdata/mouse_help_view.golden
+++ b/internal/tui/testdata/mouse_help_view.golden
@@ -1,0 +1,30 @@
+╭─────────────────────────────────────────────────────────────────────────────╮
+│                                                                             │
+│  Keyboard Shortcuts                                                         │
+│                                                                             │
+│  ←/h           Move to left column                                          │
+│  →/l           Move to right column                                         │
+│  ↓/j           Move cursor down                                             │
+│  ↑/k           Move cursor up                                               │
+│  enter         Show task detail                                             │
+│  c             Create new task in column                                    │
+│  e             Edit selected task (same flow as create)                     │
+│  m             Move task (status picker)                                    │
+│  n             Move task to next status                                     │
+│  p             Move task to previous status                                 │
+│  +/=           Raise task priority                                          │
+│  -/_           Lower task priority                                          │
+│  d             Delete task                                                  │
+│  s             Cycle sort field (priority/created/updated/title)            │
+│  S             Reverse sort direction                                       │
+│  /             Search by title, or by ID with #12 (trailing space = exact)  │
+│  r             Refresh board                                                │
+│  ?             Show this help                                               │
+│  esc/q         Quit                                                         │
+│  ctrl+c        Force quit                                                   │
+│  click         Select task; double-click opens detail                       │
+│  wheel         Move selection or scroll task detail                         │
+│                                                                             │
+│  Press any key to close                                                     │
+│                                                                             │
+╰─────────────────────────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/mouse_narrow.golden
+++ b/internal/tui/testdata/mouse_narrow.golden
@@ -1,0 +1,10 @@
+ bac...  tod...  in-...  rev...  don...
+╭──────╮        ╭──────╮        ╭──────╮
+│ #1   │(empty) │ #3   │(empty) │ #4   │
+│ Task │        │ Task │        │ Task │
+│ A    │        │ C    │        │ D    │
+│ high │        │ high │        │ low  │
+╰──────╯        │ 2h   │        ╰──────╯
+  ↓ 1...        ╰──────╯
+
+ mouse:click/doub...


### PR DESCRIPTION
## Summary

- add opt-in `kanban-md tui --mouse` support without changing keyboard defaults
- support card selection, 500 ms double-click detail opening, clickable Back, and vertical wheel navigation
- derive clipped hit targets from the renderer for narrow, short, empty, scrolled, and variable-height layouts
- extend snapshots and the PTY harness with raw mouse input, checkpoints, configurable sizes, and resize support

## Testing

- `make test`
- `golangci-lint run ./...`
- `go test ./e2e -run TestE2E_TUIMouse -count=10`
- `go test ./internal/tui -run ^$ -fuzz ^FuzzMouseLayout$ -fuzztime=30s`
- `go test -cover ./internal/tui` (94.2%)

Part 1 of #8. Drag-to-move follows in a stacked PR.