### PR TITLE
Task/438 preserve extra front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ tags:
 Optional body with more detail, context, or notes.
 ```
 
+When kanban-md updates a task, it preserves unrecognized YAML frontmatter
+properties, including nested values, tags, comments, anchors, and aliases. This
+lets other tools store their own metadata without kanban-md deleting it. These
+properties remain file-only and are not added to table, compact, or JSON output.
+
 The `config.yml` tracks board settings:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ properties remain file-only and are not added to table, compact, or JSON output.
 If a property aliases an anchor on a kanban-md field and a mutation removes that
 anchor, kanban-md refuses the write and leaves the file unchanged. Inline or
 remove the alias before retrying the mutation.
+When a kanban-md field keeps its key but changes value, aliases to that field's
+anchor follow the new value.
 
 The `config.yml` tracks board settings:
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ When kanban-md updates a task, it preserves unrecognized YAML frontmatter
 properties, including nested values, tags, comments, anchors, and aliases. This
 lets other tools store their own metadata without kanban-md deleting it. These
 properties remain file-only and are not added to table, compact, or JSON output.
+If a property aliases an anchor on a kanban-md field and a mutation removes that
+anchor, kanban-md refuses the write and leaves the file unchanged. Inline or
+remove the alias before retrying the mutation.
 
 The `config.yml` tracks board settings:
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ properties remain file-only and are not added to table, compact, or JSON output.
 kanban-md reserializes frontmatter as YAML after an update. Formatting,
 comments, and key order are not preserved. Additional properties that use
 anchors, aliases, YAML merges, explicit tags, non-string mapping keys, or other
-unsupported YAML syntax are removed when the task is updated. Unsupported
-additional properties do not prevent kanban-md from loading the task.
+unsupported YAML syntax are outside the preservation boundary. They do not
+prevent kanban-md from loading or updating the task, but their representation
+after an update is not guaranteed.
 
 The `config.yml` tracks board settings:
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ tags:
 Optional body with more detail, context, or notes.
 ```
 
+When kanban-md updates a task, it preserves the values of unrecognized YAML
+frontmatter properties composed of scalars, lists, and string-keyed maps. This
+lets other tools store their own metadata without kanban-md deleting it. These
+properties remain file-only and are not added to table, compact, or JSON output.
+
+kanban-md reserializes frontmatter as YAML after an update. Formatting,
+comments, and key order are not preserved. Additional properties that use
+anchors, aliases, YAML merges, explicit tags, non-string mapping keys, or other
+unsupported YAML syntax are removed when the task is updated. Unsupported
+additional properties do not prevent kanban-md from loading the task.
+
 The `config.yml` tracks board settings:
 
 ```yaml

--- a/docs/research/2026-08-12-preserve-extra-task-front-matter-properties.md
+++ b/docs/research/2026-08-12-preserve-extra-task-front-matter-properties.md
@@ -1,0 +1,230 @@
+---
+relationships:
+  references:
+    - internal/task/task.go
+    - internal/task/file.go
+    - internal/board/mutate.go
+    - internal/task/consistency.go
+    - internal/tui/board.go
+---
+
+# Preserve extra task front-matter properties
+
+## Conclusion
+
+kanban-md should retain the parsed YAML mapping on each task and merge typed
+field changes back into that mapping when writing. This keeps kanban-md's
+current typed task model while preserving properties it does not own.
+
+Do not add an inline `map[string]any` or `map[string]yaml.Node` to `Task`.
+The YAML library sorts inline map keys during encoding. An alias can then be
+written before its anchor, turning valid input into invalid YAML.
+
+No task-format version bump or migration is needed. The file format does not
+gain a kanban-md field. The change only stops destructive rewrites of
+user-owned fields.
+
+## Observed behavior
+
+A local reproduction created a task with these extra properties:
+
+```yaml
+external_id: sample-17 # integration-owned identifier
+relationships:
+  references:
+    - generic-record
+extension:
+  enabled: true
+```
+
+`kanban-md show 1 --json` read the task without error. Running
+`kanban-md edit 1 --priority high` removed all three properties. The body and
+canonical task fields remained.
+
+The mechanism is established:
+
+1. `task.Read` splits the file and unmarshals front matter into `Task`.
+2. `Task` contains only kanban-md's known properties.
+3. The YAML decoder ignores unknown mapping keys.
+4. Every persisted mutation marshals the resulting closed struct.
+
+The first write therefore has no representation from which it could restore an
+unknown property.
+
+## Affected write paths
+
+The loss is centralized in `task.Write`, but it is visible through every path
+that reads and rewrites an existing task:
+
+| Surface | Persistence path |
+| --- | --- |
+| Edit, claim, release, block, unblock | `board.Edit` → `task.WriteAndRename` → `task.Write` |
+| Move | `board.Move` → `task.Write` |
+| Archive and delete | `board.Archive` or `board.Delete` → `task.Write` |
+| Handoff | `board.Handoff` → `task.Write` |
+| Pick and claim | `board.PickAndClaim` → `task.Write` |
+| Terminal user interface priority change | `Board.executePriorityChange` → `task.Write` |
+| Terminal user interface edit, move, drag, and delete | Shared board mutations above |
+| Consistency repair | `repairFilenameMismatches` → `task.Write` |
+
+`create` also calls `task.Write`, but it starts a new task and has no prior
+properties to preserve. Read-only commands do not normally rewrite tasks.
+`loadConfig` can trigger a consistency repair, so a nominally read-only
+command can rewrite a task whose ID and filename disagree.
+
+## Options
+
+### Inline extension map
+
+Adding this field is the smallest change:
+
+```go
+ExtraProperties map[string]yaml.Node `yaml:",inline" json:"-"`
+```
+
+It preserves scalar types, nested values, explicit tags, and some comments. It
+also keeps JSON output unchanged.
+
+It does not preserve top-level key order or comments attached to keys. More
+seriously, go.yaml v3 sorts inline map keys. This valid input:
+
+```yaml
+z_anchor: &shared
+  enabled: true
+a_alias: *shared
+```
+
+was encoded as `a_alias` followed by `z_anchor`. Parsing the result failed
+with `unknown anchor 'shared' referenced`.
+
+This option is not safe for arbitrary YAML properties.
+
+### Decode and rewrite the whole task as an untyped mapping
+
+A `map[string]any` avoids dropping keys, but moves type handling and validation
+out of `Task`. It also loses YAML node details and makes every task consumer
+perform conversions.
+
+This replaces a useful typed model to solve a persistence concern. It is not
+recommended.
+
+### Preserve the YAML node and overlay canonical fields
+
+Store the original mapping as unexported runtime state on `Task`. Continue
+decoding canonical properties into typed fields. On write, encode those typed
+fields to a fresh canonical mapping and merge them into the original mapping.
+
+This preserves unknown key/value nodes and their order. It also keeps all
+business logic typed. go.yaml's node model retains YAML tags, anchors, aliases,
+styles, and comments, though the library does not promise byte-identical
+formatting after encoding.
+
+A throwaway prototype changed a typed title while preserving two unknown alias
+relationships, including an unknown alias that targeted an anchor on the typed
+`id` property. The merged output parsed successfully. The prototype was removed
+after the check.
+
+This is the recommended option.
+
+## Recommended implementation
+
+Keep the behavior inside `internal/task`; callers should not need to know that
+extra properties exist.
+
+1. Add an unexported `frontmatter *yaml.Node` field to `Task`, excluded from
+   YAML and JSON.
+2. Implement `UnmarshalYAML` for `Task`. Decode through a method-free alias
+   to populate typed fields, then retain the source mapping node.
+3. Implement `MarshalYAML` for `Task`. Encode the method-free alias to a
+   canonical mapping, then merge it with retained source mapping.
+4. Derive the canonical key set from `Task` YAML tags. Do not maintain a
+   second handwritten field list.
+5. For each original pair:
+   - replace a canonical value with its current typed value;
+   - omit a canonical property when its `omitempty` field is now empty;
+   - retain an unknown key and value node unchanged.
+6. Append canonical properties absent from the original mapping in struct
+   order.
+7. Preserve comments, style, and anchor name from an existing canonical node
+   when replacing its value, so an unknown alias that refers to that anchor
+   remains valid.
+
+A task constructed in memory has no retained mapping. It should marshal exactly
+as it does today. A task loaded from disk carries the mapping through board and
+Terminal User Interface (TUI) mutations automatically.
+
+Known fields remain authoritative. If a later kanban-md release adopts a name
+that was previously an extra property, the typed field owns that name after the
+upgrade. Duplicate YAML keys should remain invalid.
+
+## Compatibility
+
+- Existing task files remain readable without migration.
+- Canonical front-matter names and types do not change.
+- Unknown properties remain absent from JSON, compact, and table output. This
+  avoids an unrelated output contract change.
+- Already-stripped properties cannot be recovered.
+- Formatting may be normalized by go.yaml. Semantic values, tags, comments,
+  anchors, and aliases are the preservation target.
+- The task compatibility fixture version remains v1. Add an extra-properties
+  fixture to that version because the persisted format itself is unchanged.
+
+## Test plan
+
+### Serialization contract
+
+Add a fixture containing:
+
+- scalar, sequence, and nested mapping properties;
+- explicit string and timestamp-like scalar tags;
+- comments attached to extra keys and values;
+- an anchor followed by an alias whose lexical order is reversed;
+- an unknown alias referring to an anchor on a canonical property.
+
+Read it, mutate canonical fields, write it, and parse it again. Assert the
+unknown subtrees are semantically equal, their comments remain, and aliases
+resolve. Assert a cleared optional canonical field is removed. Assert a newly
+set optional field is appended once.
+
+Add collision tests proving canonical fields do not enter the unknown set and
+duplicate keys are still rejected. Marshal an in-memory task to prove existing
+canonical output is unchanged. Marshal to JSON to prove retained front matter
+does not leak.
+
+### Mutation contract
+
+Use a shared assertion helper against these paths:
+
+- `board.Edit`, including title rename and claim release;
+- `board.Move`, `board.Handoff`, `board.PickAndClaim`, and archive/delete;
+- consistency repair for an ID/filename mismatch;
+- direct TUI priority change.
+
+Add end-to-end coverage for representative `edit`, `move`, `pick`, and
+`archive` commands. Core serialization tests carry most edge cases; path tests
+prove no mutation bypasses the preserving writer.
+
+Run:
+
+```text
+go test -run Compat ./internal/config/ ./internal/task/
+go test ./...
+golangci-lint run ./...
+```
+
+For the implementation's load-bearing merge rules, mutation-test removal of
+unknown-pair retention, canonical replacement, and known-field omission. Each
+mutation must fail a named serialization test.
+
+## Risks
+
+The main risk is treating YAML as independent map entries when anchors and
+aliases make entry order significant. Keeping the original node order avoids
+that failure.
+
+The remaining edge is an unknown alias that targets a canonical optional field
+which a user then clears. Removing the canonical anchor would leave the alias
+invalid. The writer should validate its merged node by marshaling and parsing it
+before replacing the file, and return an actionable error instead of writing
+corrupt front matter. Atomic file replacement would further ensure the existing
+task survives any merge or validation failure.

--- a/docs/research/2026-08-12-preserve-extra-task-front-matter-properties.md
+++ b/docs/research/2026-08-12-preserve-extra-task-front-matter-properties.md
@@ -1,0 +1,111 @@
+---
+relationships:
+  references:
+    - internal/task/task.go
+    - internal/task/file.go
+    - internal/board/mutate.go
+    - internal/task/consistency.go
+    - internal/tui/board.go
+---
+
+# Preserve extra task front-matter properties
+
+## Acceptance boundary
+
+[Issue 16](https://github.com/antopolskiy/kanban-md/issues/16) establishes the
+need: tools that share task files must be able to add properties without a
+later kanban-md mutation deleting them.
+
+The accepted boundary is semantic YAML values:
+
+- preserve additional properties composed of scalars, lists, and recursively
+  string-keyed maps;
+- keep kanban-md fields typed and authoritative;
+- reserialize the complete front matter as YAML after a mutation; and
+- do not preserve formatting, comments, key order, anchors, aliases, or
+  explicit tags.
+
+Unknown properties remain file-only. Table, compact, and JSON output continue
+to expose only the typed task contract.
+
+## Observed data-loss mechanism
+
+`task.Read` previously decoded front matter into the closed `Task` struct. The
+YAML decoder ignored unknown mapping keys, and every mutation serialized that
+struct through `task.Write`. The first write therefore removed all values that
+did not have a field on `Task`.
+
+The loss is centralized in `task.Write`, but it affects every path that reads
+and rewrites an existing task:
+
+| Surface | Persistence path |
+| --- | --- |
+| Edit, claim, release, block, unblock | `board.Edit` → `task.WriteAndRename` → `task.Write` |
+| Move | `board.Move` → `task.Write` |
+| Archive and delete | `board.Archive` or `board.Delete` → `task.Write` |
+| Handoff | `board.Handoff` → `task.Write` |
+| Pick and claim | `board.PickAndClaim` → `task.Write` |
+| Terminal User Interface mutations | Shared board mutations or `task.Write` |
+| Consistency repair | `repairFilenameMismatches` → `task.Write` |
+
+`create` has no prior front matter to preserve. Read-only commands do not
+normally write, but configuration loading can trigger consistency repair.
+
+## Storage design
+
+`Task` retains an unexported `map[string]any` containing decoded values for
+properties it does not own. Custom YAML marshal and unmarshal methods keep this
+state inside `internal/task`:
+
+1. Decode the mapping into the typed task fields.
+2. Derive the canonical key set from the `Task` YAML tags.
+3. Inspect each explicit additional property and decode only supported values.
+4. Encode current canonical values from the typed task.
+5. Encode and append the additional values.
+
+The unexported map is absent from JSON output. A task constructed in memory has
+no additional values and produces the same canonical YAML as before.
+
+This design retains supported values rather than syntax nodes. Properties that
+use anchors, aliases, merges, or explicit tags are not loaded into the
+additional-property map and disappear on the first write. Comments, styles,
+and source order have no retained representation, but do not make an otherwise
+supported property unsupported.
+
+## Validation boundary
+
+Additional values are retained when their complete syntax tree contains:
+
+- unanchored, implicitly tagged YAML scalar nodes, including null;
+- sequences whose items recursively satisfy this boundary; and
+- mappings whose keys are unanchored, implicitly tagged strings and whose
+  values recursively satisfy this boundary.
+
+An additional property is omitted in full when its key or any nested value uses
+an anchor, alias, merge, explicit tag, non-string mapping key, or another YAML
+node shape. Unsupported additional properties do not prevent the task from
+loading. Duplicate YAML keys remain invalid through the YAML decoder. Canonical
+keys never enter the additional-property map, so a future typed field with the
+same name becomes authoritative automatically.
+
+## Compatibility and verification
+
+No task-format version bump or migration is required. Canonical field names and
+types do not change, and old files without additional properties retain their
+existing behavior.
+
+The verification set covers:
+
+- scalar, sequence, null, and nested string-keyed map values;
+- removal of properties containing anchors, aliases, merges, explicit tags, or
+  non-string map keys;
+- comment and key-order normalization without dropping supported values;
+- optional canonical field removal and addition;
+- absence from JSON, compact, and table output;
+- edit and title rename, move, claim, handoff, archive, consistency repair, and
+  Terminal User Interface mutation paths; and
+- the version 1 compatibility fixture.
+
+The repository has no `CONTRIBUTING.md` or pull request template. Maintainer
+pull requests use conventional commits, user-visible summaries, explicit
+validation commands, edge-case tests, README updates, and issue references.

--- a/docs/research/2026-08-12-preserve-extra-task-front-matter-properties.md
+++ b/docs/research/2026-08-12-preserve-extra-task-front-matter-properties.md
@@ -22,8 +22,8 @@ The accepted boundary is semantic YAML values:
   string-keyed maps;
 - keep kanban-md fields typed and authoritative;
 - reserialize the complete front matter as YAML after a mutation; and
-- do not preserve formatting, comments, key order, anchors, aliases, or
-  explicit tags.
+- make no preservation guarantee for formatting, comments, key order, anchors,
+  aliases, or explicit tags.
 
 Unknown properties remain file-only. Table, compact, and JSON output continue
 to expose only the typed task contract.
@@ -67,10 +67,11 @@ The unexported map is absent from JSON output. A task constructed in memory has
 no additional values and produces the same canonical YAML as before.
 
 This design retains supported values rather than syntax nodes. Properties that
-use anchors, aliases, merges, or explicit tags are not loaded into the
-additional-property map and disappear on the first write. Comments, styles,
-and source order have no retained representation, but do not make an otherwise
-supported property unsupported.
+use anchors, aliases, merges, or explicit tags are outside the preservation
+boundary. They do not prevent a task from loading or being updated, but their
+representation after an update is not guaranteed. Comments, styles, and source
+order have no retained representation, but do not make an otherwise supported
+property unsupported.
 
 ## Validation boundary
 
@@ -81,12 +82,14 @@ Additional values are retained when their complete syntax tree contains:
 - mappings whose keys are unanchored, implicitly tagged strings and whose
   values recursively satisfy this boundary.
 
-An additional property is omitted in full when its key or any nested value uses
-an anchor, alias, merge, explicit tag, non-string mapping key, or another YAML
-node shape. Unsupported additional properties do not prevent the task from
-loading. Duplicate YAML keys remain invalid through the YAML decoder. Canonical
-keys never enter the additional-property map, so a future typed field with the
-same name becomes authoritative automatically.
+An additional property is not retained as a semantic value when its key or any
+nested value uses an anchor, alias, merge, explicit tag, non-string mapping key,
+or another YAML node shape. Unsupported additional properties do not prevent
+the task from loading or being updated. Their representation after an update is
+not part of the preservation contract. Duplicate YAML keys remain invalid
+through the YAML decoder. Canonical keys never enter the additional-property
+map, so a future typed field with the same name becomes authoritative
+automatically.
 
 ## Compatibility and verification
 
@@ -97,8 +100,8 @@ existing behavior.
 The verification set covers:
 
 - scalar, sequence, null, and nested string-keyed map values;
-- removal of properties containing anchors, aliases, merges, explicit tags, or
-  non-string map keys;
+- successful load and update with properties containing anchors, aliases,
+  merges, explicit tags, or non-string map keys;
 - comment and key-order normalization without dropping supported values;
 - optional canonical field removal and addition;
 - absence from JSON, compact, and table output;

--- a/docs/research/2026-08-12-preserve-extra-task-front-matter-properties.md
+++ b/docs/research/2026-08-12-preserve-extra-task-front-matter-properties.md
@@ -10,6 +10,28 @@ relationships:
 
 # Preserve extra task front-matter properties
 
+## Upstream acceptance context
+
+[Issue 16](https://github.com/antopolskiy/kanban-md/issues/16) confirms that
+the maintainer accepts preservation of arbitrary task front-matter properties
+in principle. The requested review emphasis is edge-case coverage for mutation
+and repair mechanisms. This makes the shared `internal/task` writer and the
+consistency-repair path part of the acceptance boundary, not only direct edit
+commands.
+
+The repository has no `CONTRIBUTING.md` or pull request template. The
+maintainer-authored [PR 9](https://github.com/antopolskiy/kanban-md/pull/9) and
+[PR 10](https://github.com/antopolskiy/kanban-md/pull/10) establish the visible
+contribution pattern:
+
+- conventional commit subjects with explanatory commit bodies;
+- a pull request summary centered on user-visible behavior;
+- an explicit list of validation commands;
+- broad unit, snapshot, fuzz, and end-to-end edge-case coverage when the change
+  affects stateful interaction;
+- README changes in the same pull request when behavior is user-visible; and
+- an issue-closing reference in the pull request description.
+
 ## Conclusion
 
 kanban-md should retain the parsed YAML mapping on each task and merge typed

--- a/e2e/edit_test.go
+++ b/e2e/edit_test.go
@@ -117,6 +117,61 @@ func TestEditTitleRename(t *testing.T) {
 	}
 }
 
+func TestMutationsPreserveUnknownFrontmatter(t *testing.T) {
+	kanbanDir := initBoard(t)
+	created := mustCreateTask(t, kanbanDir, "Generic sample")
+	data, err := os.ReadFile(created.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	closing := strings.LastIndex(content, "---\n")
+	if closing <= 0 {
+		t.Fatalf("task has no closing frontmatter delimiter:\n%s", content)
+	}
+	content = content[:closing] + "custom_value: retained\n" + content[closing:]
+	if err = os.WriteFile(created.File, []byte(content), 0o600); err != nil { //nolint:gosec // test binary returned this task path
+		t.Fatal(err)
+	}
+
+	var edited taskJSON
+	r := runKanbanJSON(t, kanbanDir, &edited, "edit", "1", "--title", "Changed sample")
+	if r.exitCode != 0 {
+		t.Fatalf("edit failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+
+	r = runKanban(t, kanbanDir, "move", "1", statusTodo)
+	if r.exitCode != 0 {
+		t.Fatalf("move failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+
+	r = runKanban(t, kanbanDir, "edit", "1", "--claim", claimTestAgent)
+	if r.exitCode != 0 {
+		t.Fatalf("claim failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+
+	r = runKanban(t, kanbanDir, "archive", "1", "--claim", claimTestAgent)
+	if r.exitCode != 0 {
+		t.Fatalf("archive failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+}
+
+func assertCustomValuePreserved(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test helper receives a task path from the test binary
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "custom_value: retained"
+	if !strings.Contains(string(data), want) {
+		t.Errorf("%s does not contain %q:\n%s", path, want, data)
+	}
+}
+
 func TestEditNoChanges(t *testing.T) {
 	kanbanDir := initBoard(t)
 	mustCreateTask(t, kanbanDir, "Stable task")

--- a/e2e/edit_test.go
+++ b/e2e/edit_test.go
@@ -134,6 +134,20 @@ func TestMutationsPreserveUnknownFrontmatter(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	const listCommand = "list"
+	for _, args := range [][]string{
+		{listCommand},
+		{"--compact", listCommand},
+	} {
+		r := runKanban(t, kanbanDir, args...)
+		if r.exitCode != 0 {
+			t.Fatalf("%v failed: %s", args, r.stderr)
+		}
+		if strings.Contains(r.stdout, "custom_value") || strings.Contains(r.stdout, "retained") {
+			t.Errorf("%v exposed custom frontmatter:\n%s", args, r.stdout)
+		}
+	}
+
 	var edited taskJSON
 	r := runKanbanJSON(t, kanbanDir, &edited, "edit", "1", "--title", "Changed sample")
 	if r.exitCode != 0 {

--- a/e2e/edit_test.go
+++ b/e2e/edit_test.go
@@ -131,7 +131,7 @@ func TestMutationsPreserveUnknownFrontmatter(t *testing.T) {
 		t.Fatalf("task has no closing frontmatter delimiter:\n%s", content)
 	}
 	content = content[:closing] + "custom_value: retained\n" + content[closing:]
-	if err = os.WriteFile(created.File, []byte(content), 0o600); err != nil { //nolint:gosec // test binary returned this task path
+	if err = os.WriteFile(created.File, []byte(content), 0o600); err != nil { //nolint:gosec,nolintlint // test binary returned this task path
 		t.Fatal(err)
 	}
 
@@ -205,7 +205,7 @@ func TestReleaseRefusesToOrphanUnknownAlias(t *testing.T) {
 	if err = os.Chmod(created.File, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err = os.WriteFile(created.File, []byte(content), 0o600); err != nil { //nolint:gosec // test binary returned this task path
+	if err = os.WriteFile(created.File, []byte(content), 0o600); err != nil { //nolint:gosec,nolintlint // test binary returned this task path
 		t.Fatal(err)
 	}
 	before := []byte(content)

--- a/e2e/edit_test.go
+++ b/e2e/edit_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -161,9 +162,15 @@ func TestMutationsPreserveUnknownFrontmatter(t *testing.T) {
 	}
 	assertCustomValuePreserved(t, edited.File)
 
-	r = runKanban(t, kanbanDir, "edit", "1", "--claim", claimTestAgent)
+	r = runKanban(t, kanbanDir, "pick", "--claim", claimTestAgent, "--status", statusTodo, "--no-body")
 	if r.exitCode != 0 {
-		t.Fatalf("claim failed: %s", r.stderr)
+		t.Fatalf("pick failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+
+	r = runKanban(t, kanbanDir, "handoff", "1", "--claim", claimTestAgent, "--note", "Ready for review")
+	if r.exitCode != 0 {
+		t.Fatalf("handoff failed: %s", r.stderr)
 	}
 	assertCustomValuePreserved(t, edited.File)
 
@@ -172,6 +179,51 @@ func TestMutationsPreserveUnknownFrontmatter(t *testing.T) {
 		t.Fatalf("archive failed: %s", r.stderr)
 	}
 	assertCustomValuePreserved(t, edited.File)
+}
+
+func TestReleaseRefusesToOrphanUnknownAlias(t *testing.T) {
+	kanbanDir := initBoard(t)
+	created := mustCreateTask(t, kanbanDir, "Generic sample")
+	r := runKanban(t, kanbanDir, "edit", "1", "--claim", claimTestAgent)
+	if r.exitCode != 0 {
+		t.Fatalf("claim failed: %s", r.stderr)
+	}
+
+	data, err := os.ReadFile(created.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := strings.Replace(
+		string(data),
+		"claimed_by: "+claimTestAgent,
+		"claimed_by: &shared "+claimTestAgent+"\ncustom_copy: *shared",
+		1,
+	)
+	if content == string(data) {
+		t.Fatalf("claimed task does not contain claimed_by:\n%s", data)
+	}
+	if err = os.Chmod(created.File, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(created.File, []byte(content), 0o600); err != nil { //nolint:gosec // test binary returned this task path
+		t.Fatal(err)
+	}
+	before := []byte(content)
+
+	r = runKanban(t, kanbanDir, "edit", "1", "--release")
+	if r.exitCode == 0 {
+		t.Fatal("release succeeded after removing an anchor used by an unknown alias")
+	}
+	if !strings.Contains(r.stderr, created.File) || !strings.Contains(r.stderr, "inline or remove the alias") {
+		t.Fatalf("release error does not identify the file and remedy: %s", r.stderr)
+	}
+	after, err := os.ReadFile(created.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Errorf("release changed the file after frontmatter validation failed:\n%s", after)
+	}
 }
 
 func assertCustomValuePreserved(t *testing.T, path string) {

--- a/e2e/edit_test.go
+++ b/e2e/edit_test.go
@@ -180,7 +180,7 @@ func TestMutationsPreserveUnknownFrontmatter(t *testing.T) {
 	assertCustomValuePreserved(t, edited.File)
 }
 
-func TestReleaseDropsUnknownAliasToRemovedCanonicalField(t *testing.T) {
+func TestReleaseToleratesUnknownAliasToRemovedCanonicalField(t *testing.T) {
 	kanbanDir := initBoard(t)
 	created := mustCreateTask(t, kanbanDir, "Generic sample")
 	r := runKanban(t, kanbanDir, "edit", "1", "--claim", claimTestAgent)
@@ -211,14 +211,13 @@ func TestReleaseDropsUnknownAliasToRemovedCanonicalField(t *testing.T) {
 	if r.exitCode != 0 {
 		t.Fatalf("release failed: %s", r.stderr)
 	}
-	after, err := os.ReadFile(created.File)
-	if err != nil {
-		t.Fatal(err)
+	var released taskJSON
+	r = runKanbanJSON(t, kanbanDir, &released, "show", "1")
+	if r.exitCode != 0 {
+		t.Fatalf("show after release failed: %s", r.stderr)
 	}
-	for _, presentation := range []string{"claimed_by:", "custom_copy:", "&shared", "*shared"} {
-		if strings.Contains(string(after), presentation) {
-			t.Errorf("release retained %q after reserializing frontmatter:\n%s", presentation, after)
-		}
+	if released.ClaimedBy != "" {
+		t.Errorf("ClaimedBy = %q, want empty after release", released.ClaimedBy)
 	}
 }
 

--- a/e2e/edit_test.go
+++ b/e2e/edit_test.go
@@ -117,6 +117,123 @@ func TestEditTitleRename(t *testing.T) {
 	}
 }
 
+func TestMutationsPreserveUnknownFrontmatter(t *testing.T) {
+	kanbanDir := initBoard(t)
+	created := mustCreateTask(t, kanbanDir, "Generic sample")
+	data, err := os.ReadFile(created.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	closing := strings.LastIndex(content, "---\n")
+	if closing <= 0 {
+		t.Fatalf("task has no closing frontmatter delimiter:\n%s", content)
+	}
+	content = content[:closing] + "custom_value: retained\n" + content[closing:]
+	if err = os.WriteFile(created.File, []byte(content), 0o600); err != nil { //nolint:gosec,nolintlint // test binary returned this task path
+		t.Fatal(err)
+	}
+
+	const listCommand = "list"
+	for _, args := range [][]string{
+		{listCommand},
+		{"--compact", listCommand},
+	} {
+		r := runKanban(t, kanbanDir, args...)
+		if r.exitCode != 0 {
+			t.Fatalf("%v failed: %s", args, r.stderr)
+		}
+		if strings.Contains(r.stdout, "custom_value") || strings.Contains(r.stdout, "retained") {
+			t.Errorf("%v exposed custom frontmatter:\n%s", args, r.stdout)
+		}
+	}
+
+	var edited taskJSON
+	r := runKanbanJSON(t, kanbanDir, &edited, "edit", "1", "--title", "Changed sample")
+	if r.exitCode != 0 {
+		t.Fatalf("edit failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+
+	r = runKanban(t, kanbanDir, "move", "1", statusTodo)
+	if r.exitCode != 0 {
+		t.Fatalf("move failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+
+	r = runKanban(t, kanbanDir, "pick", "--claim", claimTestAgent, "--status", statusTodo, "--no-body")
+	if r.exitCode != 0 {
+		t.Fatalf("pick failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+
+	r = runKanban(t, kanbanDir, "handoff", "1", "--claim", claimTestAgent, "--note", "Ready for review")
+	if r.exitCode != 0 {
+		t.Fatalf("handoff failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+
+	r = runKanban(t, kanbanDir, "archive", "1", "--claim", claimTestAgent)
+	if r.exitCode != 0 {
+		t.Fatalf("archive failed: %s", r.stderr)
+	}
+	assertCustomValuePreserved(t, edited.File)
+}
+
+func TestReleaseDropsUnknownAliasToRemovedCanonicalField(t *testing.T) {
+	kanbanDir := initBoard(t)
+	created := mustCreateTask(t, kanbanDir, "Generic sample")
+	r := runKanban(t, kanbanDir, "edit", "1", "--claim", claimTestAgent)
+	if r.exitCode != 0 {
+		t.Fatalf("claim failed: %s", r.stderr)
+	}
+
+	data, err := os.ReadFile(created.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := strings.Replace(
+		string(data),
+		"claimed_by: "+claimTestAgent,
+		"claimed_by: &shared "+claimTestAgent+"\ncustom_copy: *shared",
+		1,
+	)
+	if content == string(data) {
+		t.Fatalf("claimed task does not contain claimed_by:\n%s", data)
+	}
+	if err = os.Chmod(created.File, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(created.File, []byte(content), 0o600); err != nil { //nolint:gosec,nolintlint // test binary returned this task path
+		t.Fatal(err)
+	}
+	r = runKanban(t, kanbanDir, "edit", "1", "--release")
+	if r.exitCode != 0 {
+		t.Fatalf("release failed: %s", r.stderr)
+	}
+	after, err := os.ReadFile(created.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, presentation := range []string{"claimed_by:", "custom_copy:", "&shared", "*shared"} {
+		if strings.Contains(string(after), presentation) {
+			t.Errorf("release retained %q after reserializing frontmatter:\n%s", presentation, after)
+		}
+	}
+}
+
+func assertCustomValuePreserved(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test helper receives a task path from the test binary
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "custom_value: retained"
+	if !strings.Contains(string(data), want) {
+		t.Errorf("%s does not contain %q:\n%s", path, want, data)
+	}
+}
+
 func TestEditNoChanges(t *testing.T) {
 	kanbanDir := initBoard(t)
 	mustCreateTask(t, kanbanDir, "Stable task")

--- a/internal/board/mutate_test.go
+++ b/internal/board/mutate_test.go
@@ -28,6 +28,42 @@ func containsSubstring(haystack, needle string) bool {
 	return strings.Contains(haystack, needle)
 }
 
+func TestEditPreservesUnknownFrontmatterWhenRenaming(t *testing.T) {
+	cfg, _ := setupMutateBoard(t)
+	path := filepath.Join(cfg.TasksPath(), "001-generic-sample.md")
+	content := `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_value: retained
+---
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := board.Edit(cfg, 1, "", false, func(tk *task.Task) (bool, error) {
+		tk.Title = "Changed sample"
+		return true, nil
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("Edit() error: %v", err)
+	}
+	if result.NewPath == path {
+		t.Fatal("Edit() did not rename the task file")
+	}
+	data, err := os.ReadFile(result.NewPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "custom_value: retained") {
+		t.Errorf("renamed task lost custom_value:\n%s", data)
+	}
+}
+
 func TestHandoff_MoveAndBlock(t *testing.T) {
 	cfg, kanbanDir := setupMutateBoard(t)
 

--- a/internal/task/compat_test.go
+++ b/internal/task/compat_test.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -237,6 +238,31 @@ func TestCompatV1TaskWithClaimAndClass(t *testing.T) {
 	}
 	if tk.Class != "expedite" {
 		t.Errorf("Class = %q, want %q", tk.Class, "expedite")
+	}
+}
+
+func TestCompatV1TaskPreservesSupportedAndDropsUnsupportedProperties(t *testing.T) {
+	path := filepath.Join(v1FixtureDir, "007-with-extra-properties.md")
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() v1 task with extra properties: %v", err)
+	}
+
+	tk.Priority = "high"
+	outputPath := filepath.Join(t.TempDir(), "007-with-extra-properties.md")
+	if err = Write(outputPath, tk); err != nil {
+		t.Fatalf("Write() v1 task with extra properties: %v", err)
+	}
+
+	values := readFrontmatterValues(t, outputPath)
+	want := map[string]any{"reference": frontmatterTestReference}
+	if got := values["custom_supported"]; !reflect.DeepEqual(got, want) {
+		t.Errorf("custom_supported = %#v, want %#v", got, want)
+	}
+	for _, property := range []string{"custom_source", "custom_copy", "custom_tagged", "custom_non_string_mapping"} {
+		if _, present := values[property]; present {
+			t.Errorf("unsupported property %q was preserved: %#v", property, values[property])
+		}
 	}
 }
 

--- a/internal/task/compat_test.go
+++ b/internal/task/compat_test.go
@@ -241,7 +241,7 @@ func TestCompatV1TaskWithClaimAndClass(t *testing.T) {
 	}
 }
 
-func TestCompatV1TaskPreservesSupportedAndDropsUnsupportedProperties(t *testing.T) {
+func TestCompatV1TaskPreservesSupportedAndToleratesUnsupportedProperties(t *testing.T) {
 	path := filepath.Join(v1FixtureDir, "007-with-extra-properties.md")
 	tk, err := Read(path)
 	if err != nil {
@@ -259,10 +259,8 @@ func TestCompatV1TaskPreservesSupportedAndDropsUnsupportedProperties(t *testing.
 	if got := values["custom_supported"]; !reflect.DeepEqual(got, want) {
 		t.Errorf("custom_supported = %#v, want %#v", got, want)
 	}
-	for _, property := range []string{"custom_source", "custom_copy", "custom_tagged", "custom_non_string_mapping"} {
-		if _, present := values[property]; present {
-			t.Errorf("unsupported property %q was preserved: %#v", property, values[property])
-		}
+	if got := values["priority"]; got != "high" {
+		t.Errorf("priority = %#v, want changed canonical value", got)
 	}
 }
 

--- a/internal/task/compat_test.go
+++ b/internal/task/compat_test.go
@@ -3,6 +3,8 @@ package task
 import (
 	"path/filepath"
 	"testing"
+
+	"go.yaml.in/yaml/v3"
 )
 
 const v1FixtureDir = "testdata/compat/v1/tasks"
@@ -237,6 +239,30 @@ func TestCompatV1TaskWithClaimAndClass(t *testing.T) {
 	}
 	if tk.Class != "expedite" {
 		t.Errorf("Class = %q, want %q", tk.Class, "expedite")
+	}
+}
+
+func TestCompatV1TaskPreservesUnknownProperties(t *testing.T) {
+	path := filepath.Join(v1FixtureDir, "007-with-extra-properties.md")
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() v1 task with extra properties: %v", err)
+	}
+
+	tk.Priority = "high"
+	outputPath := filepath.Join(t.TempDir(), "007-with-extra-properties.md")
+	if err = Write(outputPath, tk); err != nil {
+		t.Fatalf("Write() v1 task with extra properties: %v", err)
+	}
+
+	mapping := readFrontmatterNode(t, outputPath)
+	customSource := mappingValue(t, mapping, "custom_source")
+	if customSource.Anchor != "source" {
+		t.Errorf("custom_source anchor = %q, want source", customSource.Anchor)
+	}
+	customCopy := mappingValue(t, mapping, "custom_copy")
+	if customCopy.Kind != yaml.AliasNode || customCopy.Value != "source" {
+		t.Errorf("custom_copy = kind %d value %q, want alias source", customCopy.Kind, customCopy.Value)
 	}
 }
 

--- a/internal/task/consistency_test.go
+++ b/internal/task/consistency_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,41 @@ func TestEnsureConsistency_RepairsDuplicateMismatchAndNextID(t *testing.T) {
 	}
 	if len(report.Repairs) != 0 {
 		t.Fatalf("repairs on second run = %d, want 0", len(report.Repairs))
+	}
+}
+
+func TestEnsureConsistencyPreservesUnknownFrontmatter(t *testing.T) {
+	kanbanDir := t.TempDir()
+	cfg := config.NewDefault("Generic sample")
+	cfg.SetDir(kanbanDir)
+	if err := os.MkdirAll(cfg.TasksPath(), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cfg.TasksPath(), "099-mismatch.md")
+	content := `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_value: retained
+---
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureConsistency(cfg); err != nil {
+		t.Fatalf("EnsureConsistency() error: %v", err)
+	}
+	repairedPath := filepath.Join(cfg.TasksPath(), "001-generic-sample.md")
+	data, err := os.ReadFile(repairedPath) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "custom_value: retained") {
+		t.Errorf("consistency repair lost custom_value:\n%s", data)
 	}
 }
 

--- a/internal/task/file.go
+++ b/internal/task/file.go
@@ -48,6 +48,10 @@ func Write(path string, t *Task) error {
 	if err != nil {
 		return fmt.Errorf("marshaling frontmatter: %w", err)
 	}
+	var validated yaml.Node
+	if err = yaml.Unmarshal(fm, &validated); err != nil {
+		return fmt.Errorf("validating frontmatter: %w", err)
+	}
 
 	var buf bytes.Buffer
 	buf.WriteString("---\n")

--- a/internal/task/file.go
+++ b/internal/task/file.go
@@ -50,7 +50,11 @@ func Write(path string, t *Task) error {
 	}
 	var validated yaml.Node
 	if err = yaml.Unmarshal(fm, &validated); err != nil {
-		return fmt.Errorf("validating frontmatter: %w", err)
+		return fmt.Errorf(
+			"validating frontmatter for %s: %w; an unrecognized property may alias a kanban-md field this change removed; inline or remove the alias before retrying",
+			path,
+			err,
+		)
 	}
 
 	var buf bytes.Buffer

--- a/internal/task/file_test.go
+++ b/internal/task/file_test.go
@@ -99,6 +99,51 @@ func TestWriteNoBody(t *testing.T) {
 	}
 }
 
+func TestWritePreservesUnknownFrontmatterProperties(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "001-generic-sample.md")
+	content := `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_scalar: sample-17
+custom_nested:
+  enabled: true
+---
+
+Body
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Priority = "high"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		"custom_scalar: sample-17",
+		"custom_nested:\n    enabled: true",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("written task does not contain preserved property %q:\n%s", want, got)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // File protection: chmod behavior in Write/WriteAndRename
 // ---------------------------------------------------------------------------

--- a/internal/task/frontmatter.go
+++ b/internal/task/frontmatter.go
@@ -86,6 +86,10 @@ func mergeTaskFrontmatter(source, canonical *yaml.Node) *yaml.Node {
 		if !present {
 			continue
 		}
+		// The field key gives a top-level value stable identity, so its anchor
+		// remains bound when the typed value changes. Sequence items have no
+		// stable key and are matched by semantic value below to prevent an
+		// anchor from moving to a different item after removal.
 		preserveNodePresentation(currentValue, oldValue)
 		merged.Content = append(merged.Content, key, currentValue)
 		seen[key.Value] = true

--- a/internal/task/frontmatter.go
+++ b/internal/task/frontmatter.go
@@ -125,9 +125,36 @@ func taskYAMLKeys() map[string]struct{} {
 }
 
 func preserveNodePresentation(current, original *yaml.Node) {
-	current.Style = original.Style
 	current.Anchor = original.Anchor
 	current.HeadComment = original.HeadComment
 	current.LineComment = original.LineComment
 	current.FootComment = original.FootComment
+	if current.Kind != original.Kind {
+		return
+	}
+	current.Style = original.Style
+
+	switch current.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		for i := 0; i < len(current.Content) && i < len(original.Content); i++ {
+			preserveNodePresentation(current.Content[i], original.Content[i])
+		}
+	case yaml.MappingNode:
+		preserveMappingPresentation(current, original)
+	}
+}
+
+func preserveMappingPresentation(current, original *yaml.Node) {
+	for currentIndex := 0; currentIndex < len(current.Content); currentIndex += yamlMappingPairWidth {
+		currentKey := current.Content[currentIndex]
+		for originalIndex := 0; originalIndex < len(original.Content); originalIndex += yamlMappingPairWidth {
+			originalKey := original.Content[originalIndex]
+			if currentKey.Value != originalKey.Value {
+				continue
+			}
+			preserveNodePresentation(currentKey, originalKey)
+			preserveNodePresentation(current.Content[currentIndex+1], original.Content[originalIndex+1])
+			break
+		}
+	}
 }

--- a/internal/task/frontmatter.go
+++ b/internal/task/frontmatter.go
@@ -114,7 +114,11 @@ func mergeTaskFrontmatter(source, canonical *yaml.Node) *yaml.Node {
 }
 
 func nodeComments(node *yaml.Node) string {
-	return joinYAMLComments(node.HeadComment, node.LineComment, node.FootComment)
+	comments := joinYAMLComments(node.HeadComment, node.LineComment)
+	for _, child := range node.Content {
+		comments = joinYAMLComments(comments, nodeComments(child))
+	}
+	return joinYAMLComments(comments, node.FootComment)
 }
 
 func withLeadingComments(node *yaml.Node, comments string) *yaml.Node {
@@ -181,17 +185,52 @@ func preserveNodePresentation(current, original *yaml.Node) {
 }
 
 func preserveSequencePresentation(current, original *yaml.Node) {
-	used := make([]bool, len(original.Content))
+	if yamlNodesSemanticallyEqual(current, original) {
+		for i := range current.Content {
+			preserveNodePresentation(current.Content[i], original.Content[i])
+		}
+		return
+	}
+
+	matchedOriginal := make([]bool, len(original.Content))
 	for _, currentItem := range current.Content {
-		for originalIndex, originalItem := range original.Content {
-			if used[originalIndex] || !yamlNodesSemanticallyEqual(currentItem, originalItem) {
-				continue
-			}
-			preserveNodePresentation(currentItem, originalItem)
-			used[originalIndex] = true
-			break
+		originalIndex, unique := uniqueSequenceItemMatch(current.Content, original.Content, currentItem)
+		if !unique {
+			continue
+		}
+		preserveNodePresentation(currentItem, original.Content[originalIndex])
+		matchedOriginal[originalIndex] = true
+	}
+
+	for i, originalItem := range original.Content {
+		if !matchedOriginal[i] {
+			current.FootComment = joinYAMLComments(current.FootComment, nodeComments(originalItem))
 		}
 	}
+}
+
+func uniqueSequenceItemMatch(currentItems, originalItems []*yaml.Node, target *yaml.Node) (int, bool) {
+	currentMatches := 0
+	for _, item := range currentItems {
+		if yamlNodesSemanticallyEqual(target, item) {
+			currentMatches++
+		}
+	}
+	if currentMatches != 1 {
+		return 0, false
+	}
+
+	originalIndex := -1
+	for i, item := range originalItems {
+		if !yamlNodesSemanticallyEqual(target, item) {
+			continue
+		}
+		if originalIndex >= 0 {
+			return 0, false
+		}
+		originalIndex = i
+	}
+	return originalIndex, originalIndex >= 0
 }
 
 func yamlNodesSemanticallyEqual(left, right *yaml.Node) bool {

--- a/internal/task/frontmatter.go
+++ b/internal/task/frontmatter.go
@@ -135,13 +135,42 @@ func preserveNodePresentation(current, original *yaml.Node) {
 	current.Style = original.Style
 
 	switch current.Kind {
-	case yaml.DocumentNode, yaml.SequenceNode:
+	case yaml.DocumentNode:
 		for i := 0; i < len(current.Content) && i < len(original.Content); i++ {
 			preserveNodePresentation(current.Content[i], original.Content[i])
 		}
+	case yaml.SequenceNode:
+		preserveSequencePresentation(current, original)
 	case yaml.MappingNode:
 		preserveMappingPresentation(current, original)
 	}
+}
+
+func preserveSequencePresentation(current, original *yaml.Node) {
+	used := make([]bool, len(original.Content))
+	for _, currentItem := range current.Content {
+		for originalIndex, originalItem := range original.Content {
+			if used[originalIndex] || !yamlNodesSemanticallyEqual(currentItem, originalItem) {
+				continue
+			}
+			preserveNodePresentation(currentItem, originalItem)
+			used[originalIndex] = true
+			break
+		}
+	}
+}
+
+func yamlNodesSemanticallyEqual(left, right *yaml.Node) bool {
+	if left.Kind != right.Kind || left.Tag != right.Tag || left.Value != right.Value ||
+		len(left.Content) != len(right.Content) {
+		return false
+	}
+	for i := range left.Content {
+		if !yamlNodesSemanticallyEqual(left.Content[i], right.Content[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func preserveMappingPresentation(current, original *yaml.Node) {

--- a/internal/task/frontmatter.go
+++ b/internal/task/frontmatter.go
@@ -1,0 +1,133 @@
+// ---
+// relationships:
+//   references: 2026-08-12-preserve-extra-task-front-matter-properties
+// ---
+
+package task
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+var errTaskFrontmatterNotMapping = errors.New("task frontmatter must be a YAML mapping")
+
+const yamlMappingPairWidth = 2
+
+// taskYAML avoids recursively invoking Task's YAML methods while encoding and
+// decoding kanban-md-owned fields.
+type taskYAML Task
+
+// UnmarshalYAML decodes kanban-md-owned fields and retains the source mapping
+// used to preserve properties kanban-md does not own.
+func (t *Task) UnmarshalYAML(value *yaml.Node) error {
+	mapping, err := taskFrontmatterMapping(value)
+	if err != nil {
+		return err
+	}
+	if err = mapping.Decode((*taskYAML)(t)); err != nil {
+		return err
+	}
+	t.frontmatter = mapping
+	return nil
+}
+
+// MarshalYAML overlays current kanban-md-owned values on the source mapping.
+// Unknown key/value nodes remain in their original order.
+func (t *Task) MarshalYAML() (any, error) {
+	canonical, err := encodeCanonicalTask(t)
+	if err != nil {
+		return nil, err
+	}
+	if t.frontmatter == nil {
+		return canonical, nil
+	}
+	return mergeTaskFrontmatter(t.frontmatter, canonical), nil
+}
+
+func encodeCanonicalTask(t *Task) (*yaml.Node, error) {
+	var encoded yaml.Node
+	if err := encoded.Encode((*taskYAML)(t)); err != nil {
+		return nil, err
+	}
+	return taskFrontmatterMapping(&encoded)
+}
+
+func taskFrontmatterMapping(node *yaml.Node) (*yaml.Node, error) {
+	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, errTaskFrontmatterNotMapping
+	}
+	return node, nil
+}
+
+func mergeTaskFrontmatter(source, canonical *yaml.Node) *yaml.Node {
+	canonicalPairs := mappingPairsByKey(canonical)
+	knownKeys := taskYAMLKeys()
+	seen := make(map[string]bool, len(canonicalPairs))
+
+	merged := *source
+	merged.Content = make([]*yaml.Node, 0, len(source.Content)+len(canonical.Content))
+
+	for i := 0; i < len(source.Content); i += 2 {
+		key := source.Content[i]
+		oldValue := source.Content[i+1]
+		if _, known := knownKeys[key.Value]; !known {
+			merged.Content = append(merged.Content, key, oldValue)
+			continue
+		}
+
+		currentValue, present := canonicalPairs[key.Value]
+		if !present {
+			continue
+		}
+		preserveNodePresentation(currentValue, oldValue)
+		merged.Content = append(merged.Content, key, currentValue)
+		seen[key.Value] = true
+	}
+
+	for i := 0; i < len(canonical.Content); i += 2 {
+		key := canonical.Content[i]
+		if seen[key.Value] {
+			continue
+		}
+		merged.Content = append(merged.Content, key, canonical.Content[i+1])
+	}
+
+	return &merged
+}
+
+func mappingPairsByKey(mapping *yaml.Node) map[string]*yaml.Node {
+	pairs := make(map[string]*yaml.Node, len(mapping.Content)/yamlMappingPairWidth)
+	for i := 0; i < len(mapping.Content); i += 2 {
+		key := mapping.Content[i]
+		pairs[key.Value] = mapping.Content[i+1]
+	}
+	return pairs
+}
+
+func taskYAMLKeys() map[string]struct{} {
+	typ := reflect.TypeOf(taskYAML{})
+	keys := make(map[string]struct{}, typ.NumField())
+	for i := 0; i < typ.NumField(); i++ {
+		tag := typ.Field(i).Tag.Get("yaml")
+		name := strings.Split(tag, ",")[0]
+		if name != "" && name != "-" {
+			keys[name] = struct{}{}
+		}
+	}
+	return keys
+}
+
+func preserveNodePresentation(current, original *yaml.Node) {
+	current.Style = original.Style
+	current.Anchor = original.Anchor
+	current.HeadComment = original.HeadComment
+	current.LineComment = original.LineComment
+	current.FootComment = original.FootComment
+}

--- a/internal/task/frontmatter.go
+++ b/internal/task/frontmatter.go
@@ -1,0 +1,226 @@
+// ---
+// relationships:
+//   references: 2026-08-12-preserve-extra-task-front-matter-properties
+// ---
+
+package task
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+var errTaskFrontmatterNotMapping = errors.New("task frontmatter must be a YAML mapping")
+
+const yamlStringTag = "!!str"
+
+var canonicalTaskYAMLKeys = makeTaskYAMLKeys()
+
+// taskYAML avoids recursively invoking Task's YAML methods while encoding and
+// decoding kanban-md-owned fields.
+type taskYAML Task
+
+// UnmarshalYAML decodes kanban-md-owned fields and retains supported properties
+// kanban-md does not own.
+func (t *Task) UnmarshalYAML(value *yaml.Node) error {
+	mapping, err := taskFrontmatterMapping(value)
+	if err != nil {
+		return err
+	}
+	if err = mapping.Decode((*taskYAML)(t)); err != nil {
+		return err
+	}
+
+	t.extraProperties, err = decodeExtraProperties(mapping)
+	return err
+}
+
+// MarshalYAML encodes current kanban-md-owned values followed by the semantic
+// values of properties kanban-md does not own. YAML presentation details from
+// the input are intentionally not retained.
+func (t Task) MarshalYAML() (any, error) {
+	canonical, err := encodeCanonicalTask(&t)
+	if err != nil {
+		return nil, err
+	}
+	if len(t.extraProperties) == 0 {
+		return canonical, nil
+	}
+
+	extra, err := encodeExtraProperties(t.extraProperties)
+	if err != nil {
+		return nil, err
+	}
+	canonical.Content = append(canonical.Content, extra.Content...)
+	return canonical, nil
+}
+
+func decodeExtraProperties(mapping *yaml.Node) (map[string]any, error) {
+	decoded := make(map[string]any)
+	for i := 0; i < len(mapping.Content); i += 2 {
+		key := mapping.Content[i]
+		keyValue, supported := supportedExtraStringKey(key)
+		if !supported {
+			continue
+		}
+		if _, known := canonicalTaskYAMLKeys[keyValue]; known {
+			continue
+		}
+		value := mapping.Content[i+1]
+		if !isSupportedExtraValue(value) {
+			continue
+		}
+		var decodedValue any
+		if err := value.Decode(&decodedValue); err != nil {
+			return nil, fmt.Errorf("decoding additional frontmatter property %s: %w", keyValue, err)
+		}
+		decoded[keyValue] = decodedValue
+	}
+	return decoded, nil
+}
+
+func supportedExtraStringKey(node *yaml.Node) (string, bool) {
+	if node == nil || node.Kind != yaml.ScalarNode || hasUnsupportedYAMLSyntax(node) {
+		return "", false
+	}
+	return node.Value, node.ShortTag() == yamlStringTag
+}
+
+func isSupportedExtraValue(node *yaml.Node) bool {
+	if node == nil || hasUnsupportedYAMLSyntax(node) {
+		return false
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return true
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			if !isSupportedExtraValue(item) {
+				return false
+			}
+		}
+		return true
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			if _, supported := supportedExtraStringKey(node.Content[i]); !supported ||
+				!isSupportedExtraValue(node.Content[i+1]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func hasUnsupportedYAMLSyntax(node *yaml.Node) bool {
+	return node.Anchor != "" || node.Style&yaml.TaggedStyle != 0 ||
+		node.Tag != "" && !strings.HasPrefix(node.Tag, "!!") &&
+			!strings.HasPrefix(node.Tag, "tag:yaml.org,2002:")
+}
+
+func quoteLiteralMergeKeys(node *yaml.Node) {
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i < len(node.Content); i += 2 {
+			key := node.Content[i]
+			if key.Value == "<<" {
+				key.Tag = yamlStringTag
+				key.Style = yaml.DoubleQuotedStyle
+			}
+			quoteLiteralMergeKeys(node.Content[i+1])
+		}
+		return
+	}
+	for _, child := range node.Content {
+		quoteLiteralMergeKeys(child)
+	}
+}
+
+func encodeCanonicalTask(t *Task) (*yaml.Node, error) {
+	var encoded yaml.Node
+	if err := encoded.Encode((*taskYAML)(t)); err != nil {
+		return nil, err
+	}
+	return taskFrontmatterMapping(&encoded)
+}
+
+func encodeExtraProperties(extra map[string]any) (*yaml.Node, error) {
+	var encoded yaml.Node
+	if err := encoded.Encode(prepareExtraValue(extra)); err != nil {
+		return nil, fmt.Errorf("encoding additional frontmatter properties: %w", err)
+	}
+	mapping, err := taskFrontmatterMapping(&encoded)
+	if err != nil {
+		return nil, err
+	}
+	quoteLiteralMergeKeys(mapping)
+	return mapping, nil
+}
+
+func prepareExtraValue(value any) any {
+	switch typed := value.(type) {
+	case float64:
+		return preservedYAMLFloat(typed)
+	case []any:
+		prepared := make([]any, len(typed))
+		for i, item := range typed {
+			prepared[i] = prepareExtraValue(item)
+		}
+		return prepared
+	case map[string]any:
+		prepared := make(map[string]any, len(typed))
+		for key, item := range typed {
+			prepared[key] = prepareExtraValue(item)
+		}
+		return prepared
+	default:
+		return value
+	}
+}
+
+type preservedYAMLFloat float64
+
+func (value preservedYAMLFloat) MarshalYAML() (any, error) {
+	encoded := strconv.FormatFloat(float64(value), 'g', -1, 64)
+	switch encoded {
+	case "+Inf":
+		encoded = ".inf"
+	case "-Inf":
+		encoded = "-.inf"
+	case "NaN":
+		encoded = ".nan"
+	default:
+		if !strings.ContainsAny(encoded, ".eE") {
+			encoded += ".0"
+		}
+	}
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: encoded}, nil
+}
+
+func taskFrontmatterMapping(node *yaml.Node) (*yaml.Node, error) {
+	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, errTaskFrontmatterNotMapping
+	}
+	return node, nil
+}
+
+func makeTaskYAMLKeys() map[string]struct{} {
+	typ := reflect.TypeOf(taskYAML{})
+	keys := make(map[string]struct{}, typ.NumField())
+	for i := 0; i < typ.NumField(); i++ {
+		tag := typ.Field(i).Tag.Get("yaml")
+		name := strings.Split(tag, ",")[0]
+		if name != "" && name != "-" {
+			keys[name] = struct{}{}
+		}
+	}
+	return keys
+}

--- a/internal/task/frontmatter.go
+++ b/internal/task/frontmatter.go
@@ -187,7 +187,7 @@ func preserveNodePresentation(current, original *yaml.Node) {
 func preserveSequencePresentation(current, original *yaml.Node) {
 	if yamlNodesSemanticallyEqual(current, original) {
 		for i := range current.Content {
-			preserveNodePresentation(current.Content[i], original.Content[i])
+			current.Content[i] = original.Content[i]
 		}
 		return
 	}
@@ -234,6 +234,8 @@ func uniqueSequenceItemMatch(currentItems, originalItems []*yaml.Node, target *y
 }
 
 func yamlNodesSemanticallyEqual(left, right *yaml.Node) bool {
+	left = resolvedYAMLNode(left)
+	right = resolvedYAMLNode(right)
 	if left.Kind != right.Kind || left.Tag != right.Tag || left.Value != right.Value ||
 		len(left.Content) != len(right.Content) {
 		return false
@@ -244,6 +246,13 @@ func yamlNodesSemanticallyEqual(left, right *yaml.Node) bool {
 		}
 	}
 	return true
+}
+
+func resolvedYAMLNode(node *yaml.Node) *yaml.Node {
+	if node.Kind == yaml.AliasNode && node.Alias != nil {
+		return node.Alias
+	}
+	return node
 }
 
 func preserveMappingPresentation(current, original *yaml.Node) {

--- a/internal/task/frontmatter.go
+++ b/internal/task/frontmatter.go
@@ -73,17 +73,21 @@ func mergeTaskFrontmatter(source, canonical *yaml.Node) *yaml.Node {
 
 	merged := *source
 	merged.Content = make([]*yaml.Node, 0, len(source.Content)+len(canonical.Content))
+	pendingComments := ""
 
 	for i := 0; i < len(source.Content); i += 2 {
 		key := source.Content[i]
 		oldValue := source.Content[i+1]
 		if _, known := knownKeys[key.Value]; !known {
+			key = withLeadingComments(key, pendingComments)
+			pendingComments = ""
 			merged.Content = append(merged.Content, key, oldValue)
 			continue
 		}
 
 		currentValue, present := canonicalPairs[key.Value]
 		if !present {
+			pendingComments = joinYAMLComments(pendingComments, nodeComments(key), nodeComments(oldValue))
 			continue
 		}
 		// The field key gives a top-level value stable identity, so its anchor
@@ -91,9 +95,12 @@ func mergeTaskFrontmatter(source, canonical *yaml.Node) *yaml.Node {
 		// stable key and are matched by semantic value below to prevent an
 		// anchor from moving to a different item after removal.
 		preserveNodePresentation(currentValue, oldValue)
+		key = withLeadingComments(key, pendingComments)
+		pendingComments = ""
 		merged.Content = append(merged.Content, key, currentValue)
 		seen[key.Value] = true
 	}
+	merged.FootComment = joinYAMLComments(pendingComments, merged.FootComment)
 
 	for i := 0; i < len(canonical.Content); i += 2 {
 		key := canonical.Content[i]
@@ -104,6 +111,29 @@ func mergeTaskFrontmatter(source, canonical *yaml.Node) *yaml.Node {
 	}
 
 	return &merged
+}
+
+func nodeComments(node *yaml.Node) string {
+	return joinYAMLComments(node.HeadComment, node.LineComment, node.FootComment)
+}
+
+func withLeadingComments(node *yaml.Node, comments string) *yaml.Node {
+	if comments == "" {
+		return node
+	}
+	clone := *node
+	clone.HeadComment = joinYAMLComments(comments, clone.HeadComment)
+	return &clone
+}
+
+func joinYAMLComments(comments ...string) string {
+	nonEmpty := make([]string, 0, len(comments))
+	for _, comment := range comments {
+		if comment != "" {
+			nonEmpty = append(nonEmpty, comment)
+		}
+	}
+	return strings.Join(nonEmpty, "\n")
 }
 
 func mappingPairsByKey(mapping *yaml.Node) map[string]*yaml.Node {

--- a/internal/task/frontmatter.go
+++ b/internal/task/frontmatter.go
@@ -187,7 +187,12 @@ func preserveNodePresentation(current, original *yaml.Node) {
 func preserveSequencePresentation(current, original *yaml.Node) {
 	if yamlNodesSemanticallyEqual(current, original) {
 		for i := range current.Content {
-			current.Content[i] = original.Content[i]
+			originalItem := original.Content[i]
+			if originalItem.Kind != yaml.AliasNode || yamlNodeContains(original, originalItem.Alias) {
+				current.Content[i] = originalItem
+				continue
+			}
+			preserveNodePresentation(current.Content[i], originalItem)
 		}
 		return
 	}
@@ -253,6 +258,18 @@ func resolvedYAMLNode(node *yaml.Node) *yaml.Node {
 		return node.Alias
 	}
 	return node
+}
+
+func yamlNodeContains(root, target *yaml.Node) bool {
+	if root == target {
+		return true
+	}
+	for _, child := range root.Content {
+		if yamlNodeContains(child, target) {
+			return true
+		}
+	}
+	return false
 }
 
 func preserveMappingPresentation(current, original *yaml.Node) {

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -272,6 +272,43 @@ custom_copy: *shared
 	}
 }
 
+func TestWritePreservesUnchangedCanonicalSequenceContainingAlias(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+tags:
+  - &shared alpha
+  - *shared
+custom_copy: *shared
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Priority = "high"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() unrelated field error: %v", err)
+	}
+
+	mapping := readFrontmatterNode(t, path)
+	tags := mappingValue(t, mapping, "tags")
+	if tags.Content[0].Anchor != frontmatterTestAnchor {
+		t.Errorf("first tag anchor = %q, want %q", tags.Content[0].Anchor, frontmatterTestAnchor)
+	}
+	if tags.Content[1].Kind != yaml.AliasNode || tags.Content[1].Value != frontmatterTestAnchor {
+		t.Errorf("second tag = kind %d value %q, want alias %q", tags.Content[1].Kind, tags.Content[1].Value, frontmatterTestAnchor)
+	}
+	if customCopy := mappingValue(t, mapping, "custom_copy"); customCopy.Kind != yaml.AliasNode {
+		t.Errorf("custom_copy kind = %d, want alias", customCopy.Kind)
+	}
+}
+
 func TestWriteUpdatesOptionalCanonicalFieldsWithoutPromotingExtras(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -1,0 +1,574 @@
+// ---
+// relationships:
+//   verifies: frontmatter
+// ---
+
+package task
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	frontmatterTestReference = "sample-17"
+	frontmatterTestRetained  = "retained"
+	frontmatterTestStatus    = "todo"
+)
+
+func TestWritePreservesAdditionalSemanticValues(t *testing.T) {
+	path := writeRawTask(t, `---
+custom_scalar: "001" # presentation is not retained
+custom_float: 2.0
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_sequence:
+  - alpha
+  - alpha
+  - 3
+  - true
+  - null
+custom_mapping:
+  defaults:
+    enabled: true
+  nested:
+    enabled: true
+    references: [one, two]
+---
+
+Body
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Title = "Changed sample"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	values := readFrontmatterValues(t, path)
+	if got := values["custom_scalar"]; got != "001" {
+		t.Errorf("custom_scalar = %#v, want %q", got, "001")
+	}
+	if got := values["custom_float"]; got != float64(2) {
+		t.Errorf("custom_float = %#v (%T), want float64(2)", got, got)
+	}
+	wantSequence := []any{"alpha", "alpha", 3, true, nil}
+	if got := values["custom_sequence"]; !reflect.DeepEqual(got, wantSequence) {
+		t.Errorf("custom_sequence = %#v, want %#v", got, wantSequence)
+	}
+	wantMapping := map[string]any{
+		"defaults": map[string]any{"enabled": true},
+		"nested": map[string]any{
+			"enabled":    true,
+			"references": []any{"one", "two"},
+		},
+	}
+	if got := values["custom_mapping"]; !reflect.DeepEqual(got, wantMapping) {
+		t.Errorf("custom_mapping = %#v, want %#v", got, wantMapping)
+	}
+	if got := values["title"]; got != "Changed sample" {
+		t.Errorf("title = %#v, want changed canonical value", got)
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, presentation := range []string{"# presentation"} {
+		if strings.Contains(string(data), presentation) {
+			t.Errorf("written task retained YAML presentation %q:\n%s", presentation, data)
+		}
+	}
+}
+
+func TestWriteDropsAdditionalPropertiesWithUnsupportedYAMLSyntax(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+estimate: &shared 4h
+custom_copy: *shared
+custom_anchor: &extra anchored
+custom_tagged: !integration 001
+custom_binary: !!binary aGVsbG8=
+custom_sequence:
+  - plain
+  - &item anchored
+  - *item
+custom_mapping:
+  nested: !integration value
+custom_supported: retained # comments are discarded without dropping the value
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Estimate = ""
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	values := readFrontmatterValues(t, path)
+	if _, present := values["estimate"]; present {
+		t.Error("cleared estimate remains in frontmatter")
+	}
+	for _, key := range []string{
+		"custom_copy", "custom_anchor", "custom_tagged", "custom_binary", "custom_sequence", "custom_mapping",
+	} {
+		if _, present := values[key]; present {
+			t.Errorf("unsupported additional property %q was preserved: %#v", key, values[key])
+		}
+	}
+	if got := values["custom_supported"]; got != frontmatterTestRetained {
+		t.Errorf("custom_supported = %#v, want retained", got)
+	}
+}
+
+func TestWriteDropsTopLevelMergeValues(t *testing.T) {
+	path := writeRawTask(t, `---
+defaults: &defaults
+  external_reference: merged
+  merged_reference: sample-17
+<<: *defaults
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+external_reference: explicit
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Priority = "high"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	values := readFrontmatterValues(t, path)
+	if _, present := values["defaults"]; present {
+		t.Errorf("anchored defaults property was preserved: %#v", values["defaults"])
+	}
+	if _, present := values["merged_reference"]; present {
+		t.Errorf("merged_reference was materialized: %#v", values["merged_reference"])
+	}
+	if got := values["external_reference"]; got != "explicit" {
+		t.Errorf("external_reference = %#v, want explicit value to override merged value", got)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, presentation := range []string{"<<:", "&defaults", "*defaults"} {
+		if strings.Contains(string(data), presentation) {
+			t.Errorf("written task retained YAML merge presentation %q:\n%s", presentation, data)
+		}
+	}
+}
+
+func TestWritePreservesQuotedMergeKeyAcrossRepeatedWrites(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+defaults: &defaults
+  external_reference: ignored
+"<<":
+  external_reference: sample-17
+---
+`)
+
+	for i := 0; i < 2; i++ {
+		tk, err := Read(path)
+		if err != nil {
+			t.Fatalf("Read() cycle %d error: %v", i+1, err)
+		}
+		tk.Priority = "high"
+		if err = Write(path, tk); err != nil {
+			t.Fatalf("Write() cycle %d error: %v", i+1, err)
+		}
+	}
+
+	values := readFrontmatterValues(t, path)
+	want := map[string]any{"external_reference": "sample-17"}
+	if got := values["<<"]; !reflect.DeepEqual(got, want) {
+		t.Errorf("quoted merge-key property = %#v, want %#v", got, want)
+	}
+	if _, merged := values["external_reference"]; merged {
+		t.Errorf("quoted merge-key property was hoisted into the task: %#v", values)
+	}
+}
+
+func TestWriteDropsPropertiesWithUnsupportedKeySyntax(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+key_source: &key custom_alias_key
+*key: alias-key value
+!integration custom_tagged_key: tagged-key value
+&anchored_key custom_anchored_key: anchored-key value
+!!str custom_explicit_key: explicit-key value
+custom_mapping:
+  *key: nested alias-key value
+  !integration nested_tagged_key: nested tagged-key value
+custom_supported: retained
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	values := readFrontmatterValues(t, path)
+	for _, key := range []string{
+		"key_source", "custom_alias_key", "custom_tagged_key", "custom_anchored_key", "custom_explicit_key",
+		"custom_mapping",
+	} {
+		if _, present := values[key]; present {
+			t.Errorf("property with unsupported key syntax %q was preserved: %#v", key, values[key])
+		}
+	}
+	if got := values["custom_supported"]; got != frontmatterTestRetained {
+		t.Errorf("custom_supported = %#v, want retained", got)
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, presentation := range []string{"&key", "*key", "!integration"} {
+		if strings.Contains(string(data), presentation) {
+			t.Errorf("written task retained key presentation %q:\n%s", presentation, data)
+		}
+	}
+}
+
+func TestWriteDropsAdditionalAliasExpansionWithoutResolvingIt(t *testing.T) {
+	var content strings.Builder
+	content.WriteString("---\nid: 1\ntitle: Generic sample\nstatus: todo\npriority: medium\n")
+	content.WriteString("created: 2026-08-12T10:00:00Z\nupdated: 2026-08-12T10:00:00Z\ncustom:\n")
+	content.WriteString("  - &a0 [x, x]\n")
+	for i := 1; i <= 24; i++ {
+		fmt.Fprintf(&content, "  - &a%d [*a%d, *a%d]\n", i, i-1, i-1)
+	}
+	content.WriteString("---\n")
+	path := writeRawTask(t, content.String())
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	values := readFrontmatterValues(t, path)
+	if _, present := values["custom"]; present {
+		t.Errorf("alias-backed property was preserved: %#v", values["custom"])
+	}
+}
+
+func TestWriteKeepsCanonicalFieldsAuthoritative(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+assignee: sample-user
+custom_value: retained
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Assignee = ""
+	tk.Estimate = "2h"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	values := readFrontmatterValues(t, path)
+	if _, present := values["assignee"]; present {
+		t.Error("cleared assignee remains in frontmatter")
+	}
+	if got := values["estimate"]; got != "2h" {
+		t.Errorf("estimate = %#v, want 2h", got)
+	}
+	if got := values["custom_value"]; got != frontmatterTestRetained {
+		t.Errorf("custom_value = %#v, want retained", got)
+	}
+}
+
+func TestWriteDropsAdditionalMappingWithNonStringKey(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_mapping:
+  nested:
+    1: unsupported
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	values := readFrontmatterValues(t, path)
+	if _, present := values["custom_mapping"]; present {
+		t.Errorf("mapping with a non-string key was preserved: %#v", values["custom_mapping"])
+	}
+}
+
+func TestWriteDropsAdditionalPropertyWithNonStringKey(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+1: unsupported
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	values := readFrontmatterValues(t, path)
+	if _, present := values["1"]; present {
+		t.Errorf("property with a non-string key was preserved: %#v", values["1"])
+	}
+}
+
+func TestInMemoryTaskKeepsCanonicalYAMLAndAdditionalPropertiesOutOfJSON(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 10, 0, 0, 0, time.UTC)
+	tk := &Task{
+		ID:       1,
+		Title:    "Generic sample",
+		Status:   frontmatterTestStatus,
+		Priority: "medium",
+		Created:  now,
+		Updated:  now,
+	}
+
+	wantYAML, err := yaml.Marshal((*taskYAML)(tk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotYAML, err := yaml.Marshal(tk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotYAML, wantYAML) {
+		t.Errorf("in-memory YAML changed:\ngot:\n%s\nwant:\n%s", gotYAML, wantYAML)
+	}
+
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_value: retained
+---
+`)
+	loaded, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "custom_value") || strings.Contains(string(encoded), "extraProperties") {
+		t.Errorf("JSON exposed additional frontmatter: %s", encoded)
+	}
+	valueYAML, err := yaml.Marshal(*loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(valueYAML), "custom_value: retained") {
+		t.Errorf("marshaling a Task value dropped additional frontmatter:\n%s", valueYAML)
+	}
+}
+
+func TestReadRejectsDuplicateCanonicalKeys(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+status: done
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+---
+`)
+
+	_, err := Read(path)
+	if err == nil {
+		t.Fatal("Read() accepted duplicate canonical keys")
+	}
+	if !strings.Contains(err.Error(), "mapping key \"status\" already defined") {
+		t.Fatalf("Read() error = %v", err)
+	}
+}
+
+func TestWriteDropsAliasBackedDuplicateKey(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+key_source: &key custom_value
+custom_value: first
+*key: second
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	values := readFrontmatterValues(t, path)
+	if got := values["custom_value"]; got != "first" {
+		t.Errorf("custom_value = %#v, want first", got)
+	}
+	if _, present := values["key_source"]; present {
+		t.Errorf("anchored key source was preserved: %#v", values["key_source"])
+	}
+}
+
+func TestWriteDropsMappingWithNestedAliasBackedDuplicateKey(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+key_source: &key custom_value
+custom_mapping:
+  custom_value: first
+  *key: second
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	values := readFrontmatterValues(t, path)
+	if _, present := values["custom_mapping"]; present {
+		t.Errorf("mapping with nested alias key was preserved: %#v", values["custom_mapping"])
+	}
+	if _, present := values["key_source"]; present {
+		t.Errorf("anchored key source was preserved: %#v", values["key_source"])
+	}
+}
+
+func TestReadRejectsDuplicateAdditionalKeys(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_value: first
+custom_value: second
+---
+`)
+
+	_, err := Read(path)
+	if err == nil {
+		t.Fatal("Read() accepted duplicate additional keys")
+	}
+	if !strings.Contains(err.Error(), "mapping key \"custom_value\" already defined") {
+		t.Fatalf("Read() error = %v", err)
+	}
+}
+
+func writeRawTask(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "001-generic-sample.md")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readFrontmatterValues(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	fm, _, err := splitFrontmatter(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var values map[string]any
+	if err = yaml.Unmarshal(fm, &values); err != nil {
+		t.Fatal(err)
+	}
+	return values
+}

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	frontmatterTestAnchor = "shared"
-	frontmatterTestStatus = "todo"
+	frontmatterTestAnchor      = "shared"
+	frontmatterTestStatus      = "todo"
+	frontmatterTrailingComment = "# trailing frontmatter comment"
 )
 
 func TestWritePreservesUnknownFrontmatterNodesAndOrder(t *testing.T) {
@@ -360,9 +361,93 @@ custom_value: retained
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, comment := range []string{"# leading frontmatter comment", "# trailing frontmatter comment"} {
+	for _, comment := range []string{"# leading frontmatter comment", frontmatterTrailingComment} {
 		if !strings.Contains(string(data), comment) {
 			t.Errorf("written task does not contain %q:\n%s", comment, data)
+		}
+	}
+}
+
+func TestWritePreservesTrailingCommentWhenCanonicalFieldIsRemoved(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+# integration-owned assignment
+assignee: sample-user # keep assignment note
+# trailing frontmatter comment
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Assignee = ""
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, comment := range []string{
+		"# integration-owned assignment",
+		"# keep assignment note",
+		frontmatterTrailingComment,
+	} {
+		if !strings.Contains(string(data), comment) {
+			t.Errorf("written task lost %q after removing assignee:\n%s", comment, data)
+		}
+	}
+}
+
+func TestWriteDoesNotMutateSharedRetainedFrontmatter(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+assignee: sample-user # assignment note
+custom_value: retained
+# trailing frontmatter comment
+---
+`)
+
+	loaded, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	withoutAssignee := *loaded
+	withoutAssignee.Assignee = ""
+	if err = Write(filepath.Join(t.TempDir(), "without-assignee.md"), &withoutAssignee); err != nil {
+		t.Fatalf("Write() without assignee error: %v", err)
+	}
+
+	withAssignee := *loaded
+	withAssignee.Priority = "high"
+	outputPath := filepath.Join(t.TempDir(), "with-assignee.md")
+	if err = Write(outputPath, &withAssignee); err != nil {
+		t.Fatalf("Write() shared copy error: %v", err)
+	}
+	data, err := os.ReadFile(outputPath) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"assignee: sample-user # assignment note",
+		"# assignment note",
+		"custom_value: retained",
+		frontmatterTrailingComment,
+	} {
+		if count := strings.Count(string(data), want); count != 1 {
+			t.Errorf("shared retained frontmatter contains %d copies of %q, want 1:\n%s", count, want, data)
 		}
 	}
 }

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -17,7 +17,10 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-const frontmatterTestStatus = "todo"
+const (
+	frontmatterTestAnchor = "shared"
+	frontmatterTestStatus = "todo"
+)
 
 func TestWritePreservesUnknownFrontmatterNodesAndOrder(t *testing.T) {
 	path := writeRawTask(t, `---
@@ -66,7 +69,7 @@ Body
 	if got := mappingKey(t, mapping, "custom_scalar").HeadComment; got != "# integration-owned note" {
 		t.Errorf("custom_scalar head comment = %q", got)
 	}
-	if got := mappingValue(t, mapping, "custom_anchor"); got.Anchor != "shared" {
+	if got := mappingValue(t, mapping, "custom_anchor"); got.Anchor != frontmatterTestAnchor {
 		t.Errorf("custom_anchor anchor = %q, want shared", got.Anchor)
 	}
 	if got := mappingValue(t, mapping, "id"); got.Anchor != "canonical" {
@@ -107,6 +110,9 @@ custom_copy: *shared
 		!strings.Contains(err.Error(), "unknown anchor 'shared'") {
 		t.Fatalf("Write() error = %v", err)
 	}
+	if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), "inline or remove the alias") {
+		t.Fatalf("Write() error does not identify the file and remedy: %v", err)
+	}
 
 	after, readErr := os.ReadFile(path) //nolint:gosec // test-owned temporary path
 	if readErr != nil {
@@ -143,11 +149,44 @@ custom_copy: *shared
 
 	mapping := readFrontmatterNode(t, path)
 	tags := mappingValue(t, mapping, "tags")
-	if got := tags.Content[0].Anchor; got != "shared" {
+	if got := tags.Content[0].Anchor; got != frontmatterTestAnchor {
 		t.Errorf("first tag anchor = %q, want shared", got)
 	}
 	if got := tags.Content[1].Value; got != "gamma" {
 		t.Errorf("second tag = %q, want gamma", got)
+	}
+}
+
+func TestWriteKeepsUnknownAliasBoundToChangedCanonicalField(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+estimate: &shared 4h
+custom_copy: *shared
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Estimate = "8h"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	mapping := readFrontmatterNode(t, path)
+	estimate := mappingValue(t, mapping, "estimate")
+	if estimate.Anchor != frontmatterTestAnchor || estimate.Value != "8h" {
+		t.Errorf("estimate = anchor %q value %q, want shared 8h", estimate.Anchor, estimate.Value)
+	}
+	customCopy := mappingValue(t, mapping, "custom_copy")
+	if customCopy.Kind != yaml.AliasNode || customCopy.Value != frontmatterTestAnchor {
+		t.Errorf("custom_copy = kind %d value %q, want alias shared", customCopy.Kind, customCopy.Value)
 	}
 }
 
@@ -270,6 +309,61 @@ custom_value: retained
 	}
 	if strings.Contains(string(encoded), "custom_value") || strings.Contains(string(encoded), "frontmatter") {
 		t.Errorf("JSON exposed retained frontmatter: %s", encoded)
+	}
+}
+
+func TestReadRejectsDuplicateCanonicalKeys(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+status: done
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+---
+`)
+
+	_, err := Read(path)
+	if err == nil {
+		t.Fatal("Read() accepted duplicate canonical keys")
+	}
+	if !strings.Contains(err.Error(), "mapping key \"status\" already defined") {
+		t.Fatalf("Read() error = %v", err)
+	}
+}
+
+func TestWritePreservesFrontmatterBoundaryComments(t *testing.T) {
+	path := writeRawTask(t, `---
+# leading frontmatter comment
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_value: retained
+# trailing frontmatter comment
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Priority = "high"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, comment := range []string{"# leading frontmatter comment", "# trailing frontmatter comment"} {
+		if !strings.Contains(string(data), comment) {
+			t.Errorf("written task does not contain %q:\n%s", comment, data)
+		}
 	}
 }
 

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -232,6 +232,46 @@ custom_copy: *shared
 	}
 }
 
+func TestWriteRefusesToRetargetUnknownAliasBetweenDuplicateSequenceItems(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+tags:
+  - &shared alpha
+  - alpha
+custom_copy: *shared
+---
+`)
+	before, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Tags = tk.Tags[1:]
+	err = Write(path, tk)
+	if err == nil {
+		t.Fatal("Write() retargeted an unknown alias between duplicate sequence items")
+	}
+	if !strings.Contains(err.Error(), "unknown anchor 'shared'") {
+		t.Fatalf("Write() error = %v", err)
+	}
+	after, readErr := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(after, before) {
+		t.Error("Write() changed the file after ambiguous duplicate removal")
+	}
+}
+
 func TestWriteUpdatesOptionalCanonicalFieldsWithoutPromotingExtras(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1
@@ -402,6 +442,40 @@ assignee: sample-user # keep assignment note
 	} {
 		if !strings.Contains(string(data), comment) {
 			t.Errorf("written task lost %q after removing assignee:\n%s", comment, data)
+		}
+	}
+}
+
+func TestWritePreservesDescendantCommentsWhenCanonicalSequenceIsRemoved(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+tags:
+  # integration-owned item note
+  - alpha # keep item comment
+custom_value: retained
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Tags = nil
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, comment := range []string{"# integration-owned item note", "# keep item comment"} {
+		if !strings.Contains(string(data), comment) {
+			t.Errorf("written task lost descendant comment %q after removing tags:\n%s", comment, data)
 		}
 	}
 }

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -23,6 +23,7 @@ const (
 	frontmatterTestReference = "sample-17"
 	frontmatterTestRetained  = "retained"
 	frontmatterTestStatus    = "todo"
+	frontmatterTestTitle     = "Changed sample"
 )
 
 func TestWritePreservesAdditionalSemanticValues(t *testing.T) {
@@ -56,7 +57,7 @@ Body
 	if err != nil {
 		t.Fatalf("Read() error: %v", err)
 	}
-	tk.Title = "Changed sample"
+	tk.Title = frontmatterTestTitle
 	if err = Write(path, tk); err != nil {
 		t.Fatalf("Write() error: %v", err)
 	}
@@ -82,22 +83,12 @@ Body
 	if got := values["custom_mapping"]; !reflect.DeepEqual(got, wantMapping) {
 		t.Errorf("custom_mapping = %#v, want %#v", got, wantMapping)
 	}
-	if got := values["title"]; got != "Changed sample" {
+	if got := values["title"]; got != frontmatterTestTitle {
 		t.Errorf("title = %#v, want changed canonical value", got)
-	}
-
-	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, presentation := range []string{"# presentation"} {
-		if strings.Contains(string(data), presentation) {
-			t.Errorf("written task retained YAML presentation %q:\n%s", presentation, data)
-		}
 	}
 }
 
-func TestWriteDropsAdditionalPropertiesWithUnsupportedYAMLSyntax(t *testing.T) {
+func TestWriteToleratesAdditionalPropertiesWithUnsupportedYAMLSyntax(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1
 title: Generic sample
@@ -133,19 +124,12 @@ custom_supported: retained # comments are discarded without dropping the value
 	if _, present := values["estimate"]; present {
 		t.Error("cleared estimate remains in frontmatter")
 	}
-	for _, key := range []string{
-		"custom_copy", "custom_anchor", "custom_tagged", "custom_binary", "custom_sequence", "custom_mapping",
-	} {
-		if _, present := values[key]; present {
-			t.Errorf("unsupported additional property %q was preserved: %#v", key, values[key])
-		}
-	}
 	if got := values["custom_supported"]; got != frontmatterTestRetained {
 		t.Errorf("custom_supported = %#v, want retained", got)
 	}
 }
 
-func TestWriteDropsTopLevelMergeValues(t *testing.T) {
+func TestWriteToleratesTopLevelMergeValues(t *testing.T) {
 	path := writeRawTask(t, `---
 defaults: &defaults
   external_reference: merged
@@ -171,23 +155,11 @@ external_reference: explicit
 	}
 
 	values := readFrontmatterValues(t, path)
-	if _, present := values["defaults"]; present {
-		t.Errorf("anchored defaults property was preserved: %#v", values["defaults"])
-	}
-	if _, present := values["merged_reference"]; present {
-		t.Errorf("merged_reference was materialized: %#v", values["merged_reference"])
+	if got := values["priority"]; got != "high" {
+		t.Errorf("priority = %#v, want changed canonical value", got)
 	}
 	if got := values["external_reference"]; got != "explicit" {
 		t.Errorf("external_reference = %#v, want explicit value to override merged value", got)
-	}
-	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, presentation := range []string{"<<:", "&defaults", "*defaults"} {
-		if strings.Contains(string(data), presentation) {
-			t.Errorf("written task retained YAML merge presentation %q:\n%s", presentation, data)
-		}
 	}
 }
 
@@ -227,7 +199,7 @@ defaults: &defaults
 	}
 }
 
-func TestWriteDropsPropertiesWithUnsupportedKeySyntax(t *testing.T) {
+func TestWriteToleratesPropertiesWithUnsupportedKeySyntax(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1
 title: Generic sample
@@ -251,35 +223,21 @@ custom_supported: retained
 	if err != nil {
 		t.Fatalf("Read() error: %v", err)
 	}
+	tk.Title = frontmatterTestTitle
 	if err = Write(path, tk); err != nil {
 		t.Fatalf("Write() error: %v", err)
 	}
 
 	values := readFrontmatterValues(t, path)
-	for _, key := range []string{
-		"key_source", "custom_alias_key", "custom_tagged_key", "custom_anchored_key", "custom_explicit_key",
-		"custom_mapping",
-	} {
-		if _, present := values[key]; present {
-			t.Errorf("property with unsupported key syntax %q was preserved: %#v", key, values[key])
-		}
+	if got := values["title"]; got != frontmatterTestTitle {
+		t.Errorf("title = %#v, want changed canonical value", got)
 	}
 	if got := values["custom_supported"]; got != frontmatterTestRetained {
 		t.Errorf("custom_supported = %#v, want retained", got)
 	}
-
-	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, presentation := range []string{"&key", "*key", "!integration"} {
-		if strings.Contains(string(data), presentation) {
-			t.Errorf("written task retained key presentation %q:\n%s", presentation, data)
-		}
-	}
 }
 
-func TestWriteDropsAdditionalAliasExpansionWithoutResolvingIt(t *testing.T) {
+func TestWriteToleratesAdditionalAliasExpansion(t *testing.T) {
 	var content strings.Builder
 	content.WriteString("---\nid: 1\ntitle: Generic sample\nstatus: todo\npriority: medium\n")
 	content.WriteString("created: 2026-08-12T10:00:00Z\nupdated: 2026-08-12T10:00:00Z\ncustom:\n")
@@ -294,12 +252,16 @@ func TestWriteDropsAdditionalAliasExpansionWithoutResolvingIt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read() error: %v", err)
 	}
+	tk.Title = frontmatterTestTitle
 	if err = Write(path, tk); err != nil {
 		t.Fatalf("Write() error: %v", err)
 	}
-	values := readFrontmatterValues(t, path)
-	if _, present := values["custom"]; present {
-		t.Errorf("alias-backed property was preserved: %#v", values["custom"])
+	rewritten, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() rewritten task error: %v", err)
+	}
+	if rewritten.Title != frontmatterTestTitle {
+		t.Errorf("Title = %q, want changed canonical value", rewritten.Title)
 	}
 }
 
@@ -338,7 +300,7 @@ custom_value: retained
 	}
 }
 
-func TestWriteDropsAdditionalMappingWithNonStringKey(t *testing.T) {
+func TestWriteToleratesAdditionalMappingWithNonStringKey(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1
 title: Generic sample
@@ -356,16 +318,20 @@ custom_mapping:
 	if err != nil {
 		t.Fatalf("Read() error: %v", err)
 	}
+	tk.Title = frontmatterTestTitle
 	if err = Write(path, tk); err != nil {
 		t.Fatalf("Write() error: %v", err)
 	}
-	values := readFrontmatterValues(t, path)
-	if _, present := values["custom_mapping"]; present {
-		t.Errorf("mapping with a non-string key was preserved: %#v", values["custom_mapping"])
+	rewritten, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() rewritten task error: %v", err)
+	}
+	if rewritten.Title != frontmatterTestTitle {
+		t.Errorf("Title = %q, want changed canonical value", rewritten.Title)
 	}
 }
 
-func TestWriteDropsAdditionalPropertyWithNonStringKey(t *testing.T) {
+func TestWriteToleratesAdditionalPropertyWithNonStringKey(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1
 title: Generic sample
@@ -381,12 +347,16 @@ updated: 2026-08-12T10:00:00Z
 	if err != nil {
 		t.Fatalf("Read() error: %v", err)
 	}
+	tk.Title = frontmatterTestTitle
 	if err = Write(path, tk); err != nil {
 		t.Fatalf("Write() error: %v", err)
 	}
-	values := readFrontmatterValues(t, path)
-	if _, present := values["1"]; present {
-		t.Errorf("property with a non-string key was preserved: %#v", values["1"])
+	rewritten, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() rewritten task error: %v", err)
+	}
+	if rewritten.Title != frontmatterTestTitle {
+		t.Errorf("Title = %q, want changed canonical value", rewritten.Title)
 	}
 }
 
@@ -464,7 +434,7 @@ updated: 2026-08-12T10:00:00Z
 	}
 }
 
-func TestWriteDropsAliasBackedDuplicateKey(t *testing.T) {
+func TestWriteToleratesAliasBackedDuplicateKey(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1
 title: Generic sample
@@ -482,19 +452,20 @@ custom_value: first
 	if err != nil {
 		t.Fatalf("Read() error: %v", err)
 	}
+	tk.Priority = "high"
 	if err = Write(path, tk); err != nil {
 		t.Fatalf("Write() error: %v", err)
 	}
 	values := readFrontmatterValues(t, path)
+	if got := values["priority"]; got != "high" {
+		t.Errorf("priority = %#v, want changed canonical value", got)
+	}
 	if got := values["custom_value"]; got != "first" {
 		t.Errorf("custom_value = %#v, want first", got)
 	}
-	if _, present := values["key_source"]; present {
-		t.Errorf("anchored key source was preserved: %#v", values["key_source"])
-	}
 }
 
-func TestWriteDropsMappingWithNestedAliasBackedDuplicateKey(t *testing.T) {
+func TestWriteToleratesMappingWithNestedAliasBackedDuplicateKey(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1
 title: Generic sample
@@ -513,15 +484,16 @@ custom_mapping:
 	if err != nil {
 		t.Fatalf("Read() error: %v", err)
 	}
+	tk.Title = frontmatterTestTitle
 	if err = Write(path, tk); err != nil {
 		t.Fatalf("Write() error: %v", err)
 	}
-	values := readFrontmatterValues(t, path)
-	if _, present := values["custom_mapping"]; present {
-		t.Errorf("mapping with nested alias key was preserved: %#v", values["custom_mapping"])
+	rewritten, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() rewritten task error: %v", err)
 	}
-	if _, present := values["key_source"]; present {
-		t.Errorf("anchored key source was preserved: %#v", values["key_source"])
+	if rewritten.Title != frontmatterTestTitle {
+		t.Errorf("Title = %q, want changed canonical value", rewritten.Title)
 	}
 }
 

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -1,0 +1,284 @@
+// ---
+// relationships:
+//   verifies: frontmatter
+// ---
+
+package task
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const frontmatterTestStatus = "todo"
+
+func TestWritePreservesUnknownFrontmatterNodesAndOrder(t *testing.T) {
+	path := writeRawTask(t, `---
+custom_anchor: &shared
+  enabled: true
+id: &canonical 1
+custom_alias: *shared
+title: Generic sample
+# integration-owned note
+custom_scalar: !!str 001 # keep this comment
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_sequence:
+  - alpha
+  - beta
+custom_canonical_alias: *canonical
+---
+
+Body
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Title = "Changed sample"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	mapping := readFrontmatterNode(t, path)
+	keys := mappingKeyOrder(mapping)
+	assertKeyBefore(t, keys, "custom_anchor", "custom_alias")
+	assertKeyBefore(t, keys, "id", "custom_canonical_alias")
+
+	if got := mappingValue(t, mapping, "title").Value; got != "Changed sample" {
+		t.Errorf("title = %q, want %q", got, "Changed sample")
+	}
+	if got := mappingValue(t, mapping, "custom_scalar"); got.Tag != "!!str" || got.Value != "001" {
+		t.Errorf("custom_scalar = tag %q value %q, want !!str 001", got.Tag, got.Value)
+	} else if got.LineComment != "# keep this comment" {
+		t.Errorf("custom_scalar line comment = %q", got.LineComment)
+	}
+	if got := mappingKey(t, mapping, "custom_scalar").HeadComment; got != "# integration-owned note" {
+		t.Errorf("custom_scalar head comment = %q", got)
+	}
+	if got := mappingValue(t, mapping, "custom_anchor"); got.Anchor != "shared" {
+		t.Errorf("custom_anchor anchor = %q, want shared", got.Anchor)
+	}
+	if got := mappingValue(t, mapping, "id"); got.Anchor != "canonical" {
+		t.Errorf("id anchor = %q, want canonical", got.Anchor)
+	}
+	if got := mappingValue(t, mapping, "custom_sequence"); got.Kind != yaml.SequenceNode || len(got.Content) != 2 {
+		t.Errorf("custom_sequence was not preserved: %#v", got)
+	}
+}
+
+func TestWriteRefusesToOrphanUnknownAliasBeforeChangingFile(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+estimate: &shared 4h
+custom_copy: *shared
+---
+`)
+	before, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Estimate = ""
+	err = Write(path, tk)
+	if err == nil {
+		t.Fatal("Write() succeeded after removing an anchor used by an unknown alias")
+	}
+	if !strings.Contains(err.Error(), "validating frontmatter") ||
+		!strings.Contains(err.Error(), "unknown anchor 'shared'") {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	after, readErr := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(after, before) {
+		t.Error("Write() changed the file after frontmatter validation failed")
+	}
+}
+
+func TestWriteUpdatesOptionalCanonicalFieldsWithoutPromotingExtras(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+assignee: sample-user
+custom_value: retained
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Assignee = ""
+	tk.Estimate = "2h"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	mapping := readFrontmatterNode(t, path)
+	if mappingHasKey(mapping, "assignee") {
+		t.Error("cleared assignee remains in frontmatter")
+	}
+	if got := mappingValue(t, mapping, "estimate").Value; got != "2h" {
+		t.Errorf("estimate = %q, want 2h", got)
+	}
+	if got := mappingValue(t, mapping, "custom_value").Value; got != "retained" {
+		t.Errorf("custom_value = %q, want retained", got)
+	}
+}
+
+func TestInMemoryTaskKeepsCanonicalYAMLAndJSON(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 10, 0, 0, 0, time.UTC)
+	tk := &Task{
+		ID:       1,
+		Title:    "Generic sample",
+		Status:   frontmatterTestStatus,
+		Priority: "medium",
+		Created:  now,
+		Updated:  now,
+	}
+
+	wantYAML, err := yaml.Marshal((*taskYAML)(tk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotYAML, err := yaml.Marshal(tk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotYAML, wantYAML) {
+		t.Errorf("in-memory YAML changed:\ngot:\n%s\nwant:\n%s", gotYAML, wantYAML)
+	}
+
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_value: retained
+---
+`)
+	loaded, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "custom_value") || strings.Contains(string(encoded), "frontmatter") {
+		t.Errorf("JSON exposed retained frontmatter: %s", encoded)
+	}
+}
+
+func writeRawTask(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "001-generic-sample.md")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readFrontmatterNode(t *testing.T, path string) *yaml.Node {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	fm, _, err := splitFrontmatter(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document yaml.Node
+	if err = yaml.Unmarshal(fm, &document); err != nil {
+		t.Fatal(err)
+	}
+	mapping, err := taskFrontmatterMapping(&document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mapping
+}
+
+func mappingKeyOrder(mapping *yaml.Node) []string {
+	keys := make([]string, 0, len(mapping.Content)/2)
+	for i := 0; i < len(mapping.Content); i += 2 {
+		keys = append(keys, mapping.Content[i].Value)
+	}
+	return keys
+}
+
+func assertKeyBefore(t *testing.T, keys []string, first, second string) {
+	t.Helper()
+	firstIndex, secondIndex := -1, -1
+	for i, key := range keys {
+		switch key {
+		case first:
+			firstIndex = i
+		case second:
+			secondIndex = i
+		}
+	}
+	if firstIndex < 0 || secondIndex < 0 || firstIndex >= secondIndex {
+		t.Errorf("key order %v does not place %q before %q", keys, first, second)
+	}
+}
+
+func mappingKey(t *testing.T, mapping *yaml.Node, name string) *yaml.Node {
+	t.Helper()
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == name {
+			return mapping.Content[i]
+		}
+	}
+	t.Fatalf("mapping does not contain key %q", name)
+	return nil
+}
+
+func mappingValue(t *testing.T, mapping *yaml.Node, name string) *yaml.Node {
+	t.Helper()
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == name {
+			return mapping.Content[i+1]
+		}
+	}
+	t.Fatalf("mapping does not contain key %q", name)
+	return nil
+}
+
+func mappingHasKey(mapping *yaml.Node, name string) bool {
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -304,6 +305,46 @@ custom_copy: *shared
 	if tags.Content[1].Kind != yaml.AliasNode || tags.Content[1].Value != frontmatterTestAnchor {
 		t.Errorf("second tag = kind %d value %q, want alias %q", tags.Content[1].Kind, tags.Content[1].Value, frontmatterTestAnchor)
 	}
+	if customCopy := mappingValue(t, mapping, "custom_copy"); customCopy.Kind != yaml.AliasNode {
+		t.Errorf("custom_copy kind = %d, want alias", customCopy.Kind)
+	}
+}
+
+func TestWriteDoesNotLetCrossFieldAliasOverrideCanonicalSequence(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: &shared Alpha
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+tags:
+  - *shared
+custom_copy: *shared
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Title = "Beta"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	reloaded, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() updated task error: %v", err)
+	}
+	if reloaded.Title != "Beta" {
+		t.Errorf("Title = %q, want Beta", reloaded.Title)
+	}
+	if !slices.Equal(reloaded.Tags, []string{"Alpha"}) {
+		t.Errorf("Tags = %v, want [Alpha]", reloaded.Tags)
+	}
+
+	mapping := readFrontmatterNode(t, path)
 	if customCopy := mappingValue(t, mapping, "custom_copy"); customCopy.Kind != yaml.AliasNode {
 		t.Errorf("custom_copy kind = %d, want alias", customCopy.Kind)
 	}

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -151,6 +151,47 @@ custom_copy: *shared
 	}
 }
 
+func TestWriteRefusesToRetargetUnknownAliasAfterNestedCanonicalRemoval(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+tags:
+  - &shared alpha
+  - beta
+custom_copy: *shared
+---
+`)
+	before, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Tags = tk.Tags[1:]
+	err = Write(path, tk)
+	if err == nil {
+		t.Fatal("Write() retargeted an unknown alias after removing its anchored item")
+	}
+	if !strings.Contains(err.Error(), "unknown anchor 'shared'") {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	after, readErr := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(after, before) {
+		t.Error("Write() changed the file after nested anchor validation failed")
+	}
+}
+
 func TestWriteUpdatesOptionalCanonicalFieldsWithoutPromotingExtras(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1

--- a/internal/task/frontmatter_test.go
+++ b/internal/task/frontmatter_test.go
@@ -117,6 +117,40 @@ custom_copy: *shared
 	}
 }
 
+func TestWritePreservesUnknownAliasToNestedCanonicalNode(t *testing.T) {
+	path := writeRawTask(t, `---
+id: 1
+title: Generic sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+tags:
+  - &shared alpha
+  - beta
+custom_copy: *shared
+---
+`)
+
+	tk, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	tk.Tags[1] = "gamma"
+	if err = Write(path, tk); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+
+	mapping := readFrontmatterNode(t, path)
+	tags := mappingValue(t, mapping, "tags")
+	if got := tags.Content[0].Anchor; got != "shared" {
+		t.Errorf("first tag anchor = %q, want shared", got)
+	}
+	if got := tags.Content[1].Value; got != "gamma" {
+		t.Errorf("second tag = %q, want gamma", got)
+	}
+}
+
 func TestWriteUpdatesOptionalCanonicalFieldsWithoutPromotingExtras(t *testing.T) {
 	path := writeRawTask(t, `---
 id: 1

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -4,6 +4,8 @@ package task
 import (
 	"time"
 
+	"go.yaml.in/yaml/v3"
+
 	"github.com/antopolskiy/kanban-md/internal/date"
 )
 
@@ -34,4 +36,8 @@ type Task struct {
 
 	// File is the path to the task file (not in YAML).
 	File string `yaml:"-" json:"file,omitempty"`
+
+	// frontmatter retains the source YAML mapping so properties not owned by
+	// kanban-md survive typed task mutations.
+	frontmatter *yaml.Node
 }

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -34,4 +34,8 @@ type Task struct {
 
 	// File is the path to the task file (not in YAML).
 	File string `yaml:"-" json:"file,omitempty"`
+
+	// extraProperties retains semantic values not owned by kanban-md so they
+	// survive typed task mutations without entering command output.
+	extraProperties map[string]any
 }

--- a/internal/task/testdata/compat/v1/tasks/007-with-extra-properties.md
+++ b/internal/task/testdata/compat/v1/tasks/007-with-extra-properties.md
@@ -1,0 +1,13 @@
+---
+id: 7
+title: Generic compatibility sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_source: &source
+  reference: sample-17
+custom_copy: *source
+---
+
+Compatibility fixture with properties not owned by kanban-md.

--- a/internal/task/testdata/compat/v1/tasks/007-with-extra-properties.md
+++ b/internal/task/testdata/compat/v1/tasks/007-with-extra-properties.md
@@ -1,0 +1,18 @@
+---
+id: 7
+title: Generic compatibility sample
+status: todo
+priority: medium
+created: 2026-08-12T10:00:00Z
+updated: 2026-08-12T10:00:00Z
+custom_supported:
+  reference: sample-17
+custom_source: &source
+  reference: sample-17
+custom_copy: *source
+custom_tagged: !integration sample-17
+custom_non_string_mapping:
+  1: unsupported
+---
+
+Compatibility fixture with properties not owned by kanban-md.

--- a/internal/tui/board_test.go
+++ b/internal/tui/board_test.go
@@ -1561,6 +1561,40 @@ func TestBoard_RaisePriority(t *testing.T) {
 	_ = b.View()
 }
 
+func TestBoard_RaisePriorityPreservesUnknownFrontmatter(t *testing.T) {
+	_, cfg := setupTestBoard(t)
+	path, err := task.FindByID(cfg.TasksPath(), 1)
+	if err != nil {
+		t.Fatalf("finding task: %v", err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	closing := strings.LastIndex(content, "---\n")
+	if closing <= 0 {
+		t.Fatalf("task has no closing frontmatter delimiter:\n%s", content)
+	}
+	content = content[:closing] + "custom_value: retained\n" + content[closing:]
+	if err = os.WriteFile(path, []byte(content), 0o600); err != nil { //nolint:gosec // test-owned temporary path
+		t.Fatal(err)
+	}
+
+	b := tui.NewBoard(cfg)
+	b.SetNow(testNow)
+	b.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	_ = sendKey(b, "+")
+
+	written, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(written), "custom_value: retained") {
+		t.Errorf("priority change removed custom_value:\n%s", written)
+	}
+}
+
 func TestBoard_LowerPriority(t *testing.T) {
 	b, cfg := setupTestBoard(t)
 

--- a/internal/tui/board_test.go
+++ b/internal/tui/board_test.go
@@ -1577,7 +1577,7 @@ func TestBoard_RaisePriorityPreservesUnknownFrontmatter(t *testing.T) {
 		t.Fatalf("task has no closing frontmatter delimiter:\n%s", content)
 	}
 	content = content[:closing] + "custom_value: retained\n" + content[closing:]
-	if err = os.WriteFile(path, []byte(content), 0o600); err != nil { //nolint:gosec // test-owned temporary path
+	if err = os.WriteFile(path, []byte(content), 0o600); err != nil { //nolint:gosec,nolintlint // test-owned temporary path
 		t.Fatal(err)
 	}
 

--- a/internal/tui/board_test.go
+++ b/internal/tui/board_test.go
@@ -1744,6 +1744,40 @@ func TestBoard_RaisePriority(t *testing.T) {
 	_ = b.View()
 }
 
+func TestBoard_RaisePriorityPreservesUnknownFrontmatter(t *testing.T) {
+	_, cfg := setupTestBoard(t)
+	path, err := task.FindByID(cfg.TasksPath(), 1)
+	if err != nil {
+		t.Fatalf("finding task: %v", err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	closing := strings.LastIndex(content, "---\n")
+	if closing <= 0 {
+		t.Fatalf("task has no closing frontmatter delimiter:\n%s", content)
+	}
+	content = content[:closing] + "custom_value: retained\n" + content[closing:]
+	if err = os.WriteFile(path, []byte(content), 0o600); err != nil { //nolint:gosec,nolintlint // test-owned temporary path
+		t.Fatal(err)
+	}
+
+	b := tui.NewBoard(cfg)
+	b.SetNow(testNow)
+	b.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	_ = sendKey(b, "+")
+
+	written, err := os.ReadFile(path) //nolint:gosec // test-owned temporary path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(written), "custom_value: retained") {
+		t.Errorf("priority change removed custom_value:\n%s", written)
+	}
+}
+
 func TestBoard_LowerPriority(t *testing.T) {
 	b, cfg := setupTestBoard(t)
 


### PR DESCRIPTION
  ## Summary

  - preserve unrecognized YAML task frontmatter properties across task mutations
  - keep kanban-md fields typed and authoritative while additional properties remain file-only
  - retain nested values, explicit tags, comments, anchors, aliases, and safe key ordering
  - refuse writes before changing a task when a mutation would orphan or ambiguously retarget an alias
  - preserve properties through edit, move, pick, handoff, archive, release, TUI priority changes, and consistency repair
  - document the preservation and alias-safety behavior in the README

  ## Testing

  - `go test ./... -count=1`
  - `go test -run Compat ./internal/config/ ./internal/task/ -count=1`
  - `go test -race ./internal/task -count=1`
  - `golangci-lint run --new-from-rev=main ./...`
  - mutation checks for unknown-node retention, canonical-field authority, alias safety, comment carry-forward, and retained-node immutability

  Closes #16.