### PR TITLE
feat: add --parent flag to pick command

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Atomically find and claim the next available task. Designed for multi-agent work
 kanban-md pick --claim agent-1
 kanban-md pick --claim agent-1 --status todo --move in-progress
 kanban-md pick --claim agent-1 --tags backend
+kanban-md pick --claim agent-1 --parent 42
 kanban-md pick --claim agent-1 --no-body
 ```
 
@@ -427,6 +428,7 @@ kanban-md pick --claim agent-1 --no-body
 | `--status` | all non-terminal | Source status(es) to pick from (comma-separated) |
 | `--move` | | Also move picked task to this status |
 | `--tags` | | Only pick tasks matching at least one tag |
+| `--parent` | | Only pick tasks that are children of this parent task ID |
 | `--no-body` | false | Show only the pick confirmation line (skip full task details) |
 
 By default, `pick` prints the one-line confirmation and then the full task details (same as `show`, including body) so agents do not need a follow-up `show` command.

--- a/cmd/move_pick_coverage_test.go
+++ b/cmd/move_pick_coverage_test.go
@@ -454,7 +454,7 @@ func TestExecutePick_NoCandidates(t *testing.T) {
 		t.Fatal(err)
 	}
 	// No tasks created — nothing to pick.
-	_, _, err = executePick(cfg, "agent", "", "", nil)
+	_, _, err = executePick(cfg, "agent", "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error when nothing to pick")
 	}
@@ -475,7 +475,7 @@ func TestExecutePick_Success(t *testing.T) {
 	}
 	createTaskFileWithStatus(t, cfg.TasksPath(), 1, "pickable-task", "backlog")
 
-	picked, oldStatus, pickErr := executePick(cfg, "test-agent", "", "", nil)
+	picked, oldStatus, pickErr := executePick(cfg, "test-agent", "", "", nil, nil)
 	if pickErr != nil {
 		t.Fatalf("executePick error: %v", pickErr)
 	}
@@ -498,7 +498,7 @@ func TestExecutePick_WithMove(t *testing.T) {
 	}
 	createTaskFileWithStatus(t, cfg.TasksPath(), 1, "pick-and-move", "backlog")
 
-	picked, oldStatus, pickErr := executePick(cfg, "test-agent", "", "todo", nil)
+	picked, oldStatus, pickErr := executePick(cfg, "test-agent", "", "todo", nil, nil)
 	if pickErr != nil {
 		t.Fatalf("executePick error: %v", pickErr)
 	}
@@ -518,7 +518,7 @@ func TestExecutePick_MoveIdempotent(t *testing.T) {
 	}
 	createTaskFileWithStatus(t, cfg.TasksPath(), 1, "already-there", "todo")
 
-	picked, oldStatus, pickErr := executePick(cfg, "test-agent", "", "todo", nil)
+	picked, oldStatus, pickErr := executePick(cfg, "test-agent", "", "todo", nil, nil)
 	if pickErr != nil {
 		t.Fatalf("executePick error: %v", pickErr)
 	}
@@ -541,7 +541,7 @@ func TestExecutePick_StatusFilter(t *testing.T) {
 	createTaskFileWithStatus(t, cfg.TasksPath(), 2, "in-todo", "todo")
 
 	// Pick only from "todo" — should pick task #2.
-	picked, _, pickErr := executePick(cfg, "test-agent", "todo", "", nil)
+	picked, _, pickErr := executePick(cfg, "test-agent", "todo", "", nil, nil)
 	if pickErr != nil {
 		t.Fatalf("executePick error: %v", pickErr)
 	}
@@ -568,7 +568,7 @@ func TestExecutePick_WIPViolationOnMove(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = executePick(cfg, "test-agent", "backlog", "todo", nil)
+	_, _, err = executePick(cfg, "test-agent", "backlog", "todo", nil, nil)
 	if err == nil {
 		t.Fatal("expected WIP limit error on move")
 	}

--- a/cmd/pick.go
+++ b/cmd/pick.go
@@ -26,6 +26,7 @@ func init() {
 	pickCmd.Flags().String("status", "", "status column to pick from (default: all non-terminal)")
 	pickCmd.Flags().String("move", "", "also move the picked task to this status")
 	pickCmd.Flags().StringSlice("tags", nil, "filter by tags (comma-separated, OR logic)")
+	pickCmd.Flags().Int("parent", 0, "filter to children of this parent task ID")
 	pickCmd.Flags().Bool("no-body", false, "suppress full task details after pick")
 	_ = pickCmd.MarkFlagRequired("claim")
 	rootCmd.AddCommand(pickCmd)
@@ -43,11 +44,17 @@ func runPick(cmd *cobra.Command, _ []string) error {
 	tags, _ := cmd.Flags().GetStringSlice("tags")
 	noBody, _ := cmd.Flags().GetBool("no-body")
 
+	var parent *int
+	if cmd.Flags().Changed("parent") {
+		v, _ := cmd.Flags().GetInt("parent")
+		parent = &v
+	}
+
 	if err = validatePickFlags(cfg, statusFilter, moveTarget); err != nil {
 		return err
 	}
 
-	picked, oldStatus, err := executePick(cfg, claimant, statusFilter, moveTarget, tags)
+	picked, oldStatus, err := executePick(cfg, claimant, statusFilter, moveTarget, tags, parent)
 	if err != nil {
 		return err
 	}
@@ -69,12 +76,13 @@ func validatePickFlags(cfg *config.Config, statusFilter, moveTarget string) erro
 	return nil
 }
 
-func executePick(cfg *config.Config, claimant, statusFilter, moveTarget string, tags []string) (*task.Task, string, error) {
+func executePick(cfg *config.Config, claimant, statusFilter, moveTarget string, tags []string, parent *int) (*task.Task, string, error) {
 	params := board.PickAndClaimParams{
 		Claimant:     claimant,
 		StatusFilter: statusFilter,
 		MoveTarget:   moveTarget,
 		Tags:         tags,
+		Parent:       parent,
 	}
 
 	picked, oldStatus, warnings, err := board.PickAndClaim(cfg, params, time.Now())

--- a/e2e/pick_test.go
+++ b/e2e/pick_test.go
@@ -72,6 +72,22 @@ func TestPickWithTagFilter(t *testing.T) {
 	}
 }
 
+func TestPickWithParentFilter(t *testing.T) {
+	kanbanDir := initBoard(t)
+	mustCreateTask(t, kanbanDir, "Parent task")
+	mustCreateTask(t, kanbanDir, "Orphan task")
+	mustCreateTask(t, kanbanDir, "Child task", "--parent", "1")
+
+	var picked taskJSON
+	r := runKanbanJSON(t, kanbanDir, &picked, "pick", "--claim", claimAgent1, "--parent", "1")
+	if r.exitCode != 0 {
+		t.Fatalf("pick --parent failed (exit %d): %s", r.exitCode, r.stderr)
+	}
+	if picked.Title != "Child task" {
+		t.Errorf("picked title = %q, want %q", picked.Title, "Child task")
+	}
+}
+
 func TestPickNothingAvailable(t *testing.T) {
 	kanbanDir := initBoard(t)
 

--- a/internal/board/mutate.go
+++ b/internal/board/mutate.go
@@ -588,6 +588,7 @@ type PickAndClaimParams struct {
 	StatusFilter string
 	MoveTarget   string
 	Tags         []string
+	Parent       *int
 }
 
 // PickAndClaim finds the highest-priority task and atomically claims it. Any
@@ -616,6 +617,7 @@ func PickAndClaim(cfg *config.Config, params PickAndClaimParams, now time.Time) 
 	opts := PickOptions{
 		ClaimTimeout: cfg.ClaimTimeoutDuration(),
 		Tags:         params.Tags,
+		Parent:       params.Parent,
 	}
 	if params.StatusFilter != "" {
 		opts.Statuses = []string{params.StatusFilter}

--- a/internal/board/pick.go
+++ b/internal/board/pick.go
@@ -13,6 +13,7 @@ type PickOptions struct {
 	Statuses     []string      // status columns to pick from (empty = all non-terminal)
 	ClaimTimeout time.Duration // claim expiration for filtering
 	Tags         []string      // optional tag filter (OR logic: task must have at least one)
+	Parent       *int          // optional parent filter (only children of this task ID)
 }
 
 // Pick finds the highest-priority unclaimed, unblocked task matching criteria.
@@ -48,6 +49,9 @@ func pickCandidates(cfg *config.Config, tasks []*task.Task, opts PickOptions) []
 			continue
 		}
 		if len(opts.Tags) > 0 && !hasAnyTag(t.Tags, opts.Tags) {
+			continue
+		}
+		if opts.Parent != nil && (t.Parent == nil || *t.Parent != *opts.Parent) {
 			continue
 		}
 		candidates = append(candidates, t)

--- a/internal/board/pick_test.go
+++ b/internal/board/pick_test.go
@@ -179,6 +179,57 @@ func TestPickWithMultipleTagFilter(t *testing.T) {
 	}
 }
 
+func TestPickWithParentFilter(t *testing.T) {
+	cfg := newPickTestConfig()
+	p1, p2 := 10, 20
+	tasks := []*task.Task{
+		{ID: 1, Status: "todo", Priority: "critical"},
+		{ID: 2, Status: "todo", Priority: "high", Parent: &p1},
+		{ID: 3, Status: "todo", Priority: "critical", Parent: &p2},
+	}
+
+	parent := 10
+	picked := Pick(cfg, tasks, PickOptions{Parent: &parent})
+	if picked == nil {
+		t.Fatal("Pick() returned nil, want task #2")
+	}
+	if picked.ID != 2 {
+		t.Errorf("Pick() ID = %d, want 2 (parent filter)", picked.ID)
+	}
+}
+
+func TestPickWithParentFilterNoMatch(t *testing.T) {
+	cfg := newPickTestConfig()
+	p1 := 10
+	tasks := []*task.Task{
+		{ID: 1, Status: "todo", Priority: "critical"},
+		{ID: 2, Status: "todo", Priority: "high", Parent: &p1},
+	}
+
+	parent := 99
+	if picked := Pick(cfg, tasks, PickOptions{Parent: &parent}); picked != nil {
+		t.Errorf("Pick() ID = %d, want nil (no child of parent 99)", picked.ID)
+	}
+}
+
+func TestPickWithParentAndTagFilter(t *testing.T) {
+	cfg := newPickTestConfig()
+	p1 := 10
+	tasks := []*task.Task{
+		{ID: 1, Status: "todo", Priority: "critical", Parent: &p1, Tags: []string{"backend"}},
+		{ID: 2, Status: "todo", Priority: "high", Parent: &p1, Tags: []string{"frontend"}},
+	}
+
+	parent := 10
+	picked := Pick(cfg, tasks, PickOptions{Parent: &parent, Tags: []string{"frontend"}})
+	if picked == nil {
+		t.Fatal("Pick() returned nil, want task #2")
+	}
+	if picked.ID != 2 {
+		t.Errorf("Pick() ID = %d, want 2 (parent+tag filter)", picked.ID)
+	}
+}
+
 func TestPickExpediteBeforeStandard(t *testing.T) {
 	cfg := newPickTestConfig()
 	tasks := []*task.Task{


### PR DESCRIPTION
## Context

Follow-up to #11. As discussed in [that thread](https://github.com/antopolskiy/kanban-md/issues/11#issuecomment-5327093180), once an epic is broken into children via `parent`, an orchestrating agent needs a way to hand off "work on the next available child of this epic" to sub-agents — without hand-filtering `list --parent` output first and passing IDs around.

This adds a `--parent` filter to `pick`, mirroring the filter that already exists on `list --parent`, so:

```
kanban-md pick --claim <agent> --parent <epic-id> --status todo --move in-progress
```

picks and claims the next available task whose `parent` matches, instead of any task on the board.

## Changes

- `cmd/pick.go`: new `--parent` flag, threaded into the pick filter options.
- `internal/board/pick.go` / `internal/board/mutate.go`: filter candidates by `ParentID` alongside existing status/tag filters.
- Tests: `internal/board/pick_test.go`, `cmd/move_pick_coverage_test.go`, `e2e/pick_test.go` cover picking scoped to a parent, no matching children, and interaction with existing pick filters.
- `README.md`: documents the new flag with an example.
