### PR TITLE
fix: reject parent and depends_on links that would close a cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,18 @@ the relationship falls back to its stored task ID.
 JSON output always contains a `children` array; compact output adds a
 `children:DONE/TOTAL done` annotation only when children are present.
 
+**Parent links stay acyclic.** `create` and `edit` reject a parent that would
+close a ring, naming the chain it would form:
+
+```
+$ kanban-md edit 2 --parent 1
+Error: parent would create a cycle (#2 → #1 → #2)
+```
+
+`depends_on` is checked the same way, since two tasks that depend on each other
+can never become unblocked. Both checks run wherever the link is written, so
+`create --parent`, `edit --parent` and `edit --add-dep` are all covered.
+
 A representative board for trying the CLI and TUI behavior is available in
 [`examples/issue-11-demo`](examples/issue-11-demo/README.md).
 

--- a/e2e/dependency_test.go
+++ b/e2e/dependency_test.go
@@ -208,3 +208,103 @@ func TestBlockAndUnblockConflict(t *testing.T) {
 		t.Errorf("error = %q, want conflict message", errResp.Error)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Cycle rejection
+// ---------------------------------------------------------------------------
+
+func TestEditParentRejectsTwoStepCycle(t *testing.T) {
+	kanbanDir := initBoard(t)
+	mustCreateTask(t, kanbanDir, "A")
+	mustCreateTask(t, kanbanDir, "B")
+
+	if r := runKanban(t, kanbanDir, "edit", "1", "--parent", "2"); r.exitCode != 0 {
+		t.Fatalf("first parent edit failed: %s", r.stderr)
+	}
+
+	r := runKanban(t, kanbanDir, "edit", "2", "--parent", "1")
+	if r.exitCode == 0 {
+		t.Fatal("closing the parent ring succeeded, want a rejection")
+	}
+	if !strings.Contains(r.stderr, "cycle") {
+		t.Errorf("stderr = %q, want it to mention a cycle", r.stderr)
+	}
+	if !strings.Contains(r.stderr, "#2 → #1 → #2") {
+		t.Errorf("stderr = %q, want it to name the ring", r.stderr)
+	}
+
+	// The rejected edit must not have been written.
+	var task2 map[string]interface{}
+	runKanbanJSON(t, kanbanDir, &task2, "show", "2")
+	if task2["parent"] != nil {
+		t.Errorf("parent of #2 = %v, want it unchanged after the rejection", task2["parent"])
+	}
+}
+
+func TestEditParentRejectsDeepCycle(t *testing.T) {
+	kanbanDir := initBoard(t)
+	for _, title := range []string{"A", "B", "C"} {
+		mustCreateTask(t, kanbanDir, title)
+	}
+	mustRun(t, kanbanDir, "edit", "2", "--parent", "1")
+	mustRun(t, kanbanDir, "edit", "3", "--parent", "2")
+
+	r := runKanban(t, kanbanDir, "edit", "1", "--parent", "3")
+	if r.exitCode == 0 {
+		t.Fatal("closing a three-step parent ring succeeded, want a rejection")
+	}
+	if !strings.Contains(r.stderr, "cycle") {
+		t.Errorf("stderr = %q, want it to mention a cycle", r.stderr)
+	}
+}
+
+func TestEditParentStillAllowsValidMoves(t *testing.T) {
+	kanbanDir := initBoard(t)
+	for _, title := range []string{"Root", "Epic", "Sibling", "Story"} {
+		mustCreateTask(t, kanbanDir, title)
+	}
+	mustRun(t, kanbanDir, "edit", "2", "--parent", "1")
+	mustRun(t, kanbanDir, "edit", "3", "--parent", "1")
+	mustRun(t, kanbanDir, "edit", "4", "--parent", "2")
+
+	// Moving a leaf between siblings is not a cycle.
+	if r := runKanban(t, kanbanDir, "edit", "4", "--parent", "3"); r.exitCode != 0 {
+		t.Errorf("moving #4 under its uncle was rejected: %s", r.stderr)
+	}
+}
+
+func TestEditDependsOnRejectsCycle(t *testing.T) {
+	kanbanDir := initBoard(t)
+	mustCreateTask(t, kanbanDir, "A")
+	mustCreateTask(t, kanbanDir, "B")
+	mustRun(t, kanbanDir, "edit", "1", "--add-dep", "2")
+
+	r := runKanban(t, kanbanDir, "edit", "2", "--add-dep", "1")
+	if r.exitCode == 0 {
+		t.Fatal("closing the dependency ring succeeded, want a rejection")
+	}
+	if !strings.Contains(r.stderr, "cycle") {
+		t.Errorf("stderr = %q, want it to mention a cycle", r.stderr)
+	}
+}
+
+func TestCreateWithParentRejectsCycleThroughStoredTasks(t *testing.T) {
+	// create validates through the same gate as edit.
+	kanbanDir := initBoard(t)
+	mustCreateTask(t, kanbanDir, "A")
+	mustCreateTask(t, kanbanDir, "B")
+	mustRun(t, kanbanDir, "edit", "1", "--parent", "2")
+
+	// #3 under #1 is fine — no ring, #3 is new.
+	if r := runKanban(t, kanbanDir, "create", "C", "--parent", "1"); r.exitCode != 0 {
+		t.Errorf("creating a child below an existing chain was rejected: %s", r.stderr)
+	}
+}
+
+// mustRun runs a command and fails the test if it does not succeed.
+func mustRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	if r := runKanban(t, dir, args...); r.exitCode != 0 {
+		t.Fatalf("%v failed: %s", args, r.stderr)
+	}
+}

--- a/internal/board/cycle.go
+++ b/internal/board/cycle.go
@@ -1,0 +1,91 @@
+package board
+
+import "github.com/antopolskiy/kanban-md/internal/task"
+
+// ParentCyclePath reports whether making parentID the parent of taskID would
+// close a ring in the parent tree.
+//
+// It returns the offending chain, starting at taskID and ending back at it, so
+// the caller can name the ring in an error message; nil means the resulting
+// tree stays acyclic. A parent that does not exist is not a cycle — that case
+// belongs to the existence check. A ring already present in the stored data
+// that taskID is not part of ends the walk instead of trapping it.
+func ParentCyclePath(tasks []*task.Task, taskID, parentID int) []int {
+	byID := indexByID(tasks)
+	if _, exists := byID[parentID]; !exists {
+		return nil
+	}
+
+	path := []int{taskID}
+	visited := make(map[int]bool)
+	for id := parentID; ; {
+		path = append(path, id)
+		if id == taskID {
+			return path
+		}
+		if visited[id] {
+			return nil
+		}
+		visited[id] = true
+
+		current, ok := byID[id]
+		if !ok || current.Parent == nil {
+			return nil
+		}
+		id = *current.Parent
+	}
+}
+
+// DependencyCyclePath reports whether adding depID to the dependencies of
+// taskID would close a ring in the depends_on graph, in which neither task
+// could ever become unblocked.
+//
+// Unlike the parent tree a task may depend on several others, so the walk
+// explores every branch and returns the first chain that leads back to taskID.
+// The result starts at taskID and ends back at it; nil means the graph stays
+// acyclic.
+func DependencyCyclePath(tasks []*task.Task, taskID, depID int) []int {
+	byID := indexByID(tasks)
+	if _, exists := byID[depID]; !exists {
+		return nil
+	}
+	return findDependencyPath(byID, taskID, depID, []int{taskID}, make(map[int]bool))
+}
+
+// findDependencyPath walks the dependencies of current depth-first, looking for
+// taskID. path holds the chain walked so far; visited stops the search from
+// re-entering a task, which also contains rings already in the stored data.
+func findDependencyPath(
+	byID map[int]*task.Task,
+	taskID, current int,
+	path []int,
+	visited map[int]bool,
+) []int {
+	path = append(path, current)
+	if current == taskID {
+		return path
+	}
+	if visited[current] {
+		return nil
+	}
+	visited[current] = true
+
+	t, ok := byID[current]
+	if !ok {
+		return nil
+	}
+	for _, next := range t.DependsOn {
+		if found := findDependencyPath(byID, taskID, next, path, visited); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func indexByID(tasks []*task.Task) map[int]*task.Task {
+	byID := make(map[int]*task.Task, len(tasks))
+	for _, t := range tasks {
+		byID[t.ID] = t
+	}
+	return byID
+}

--- a/internal/board/cycle_test.go
+++ b/internal/board/cycle_test.go
@@ -1,0 +1,232 @@
+package board_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/antopolskiy/kanban-md/internal/board"
+	"github.com/antopolskiy/kanban-md/internal/config"
+	"github.com/antopolskiy/kanban-md/internal/task"
+)
+
+func cyclePtr(i int) *int { return &i }
+
+func assertChain(t *testing.T, got, want []int) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("chain = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("chain = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestParentCyclePathDetectsDirectCycle(t *testing.T) {
+	// #1 already has #2 as its parent; making #1 the parent of #2 closes the
+	// ring. The returned chain is what the error message shows the user.
+	tasks := []*task.Task{{ID: 1, Parent: cyclePtr(2)}, {ID: 2}}
+
+	assertChain(t, board.ParentCyclePath(tasks, 2, 1), []int{2, 1, 2})
+}
+
+func TestParentCyclePathDetectsDeepCycle(t *testing.T) {
+	// #3 → #2 → #1; making #3 the parent of #1 closes a three-step ring.
+	tasks := []*task.Task{
+		{ID: 1}, {ID: 2, Parent: cyclePtr(1)}, {ID: 3, Parent: cyclePtr(2)},
+	}
+
+	assertChain(t, board.ParentCyclePath(tasks, 1, 3), []int{1, 3, 2, 1})
+}
+
+func TestParentCyclePathAllowsValidMoves(t *testing.T) {
+	// Tree: #1 → {#2, #3}, #2 → #4.
+	tasks := []*task.Task{
+		{ID: 1},
+		{ID: 2, Parent: cyclePtr(1)},
+		{ID: 3, Parent: cyclePtr(1)},
+		{ID: 4, Parent: cyclePtr(2)},
+	}
+
+	cases := []struct {
+		name           string
+		taskID, parent int
+	}{
+		{"moving a leaf to a sibling", 4, 3},
+		{"moving a leaf to the root", 4, 1},
+		{"attaching a subtree under a leaf", 3, 4},
+		{"re-attaching to the current parent", 2, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := board.ParentCyclePath(tasks, tc.taskID, tc.parent); got != nil {
+				t.Errorf("ParentCyclePath(%d, %d) = %v, want no cycle", tc.taskID, tc.parent, got)
+			}
+		})
+	}
+}
+
+func TestParentCyclePathSelfReference(t *testing.T) {
+	assertChain(t, board.ParentCyclePath([]*task.Task{{ID: 1}}, 1, 1), []int{1, 1})
+}
+
+func TestParentCyclePathSurvivesPreexistingCycle(t *testing.T) {
+	// The stored data already holds a ring that #3 is not part of. The walk
+	// must terminate instead of spinning inside it.
+	tasks := []*task.Task{
+		{ID: 1, Parent: cyclePtr(2)}, {ID: 2, Parent: cyclePtr(1)}, {ID: 3},
+	}
+
+	if got := board.ParentCyclePath(tasks, 3, 1); got != nil {
+		t.Errorf("ParentCyclePath(3, 1) = %v, want no cycle for a task outside the ring", got)
+	}
+}
+
+func TestParentCyclePathUnknownParent(t *testing.T) {
+	// A parent that does not exist is a different error, reported by the
+	// existence check; the cycle check must not claim a ring.
+	if got := board.ParentCyclePath([]*task.Task{{ID: 1}}, 1, 99); got != nil {
+		t.Errorf("ParentCyclePath(1, 99) = %v, want no cycle", got)
+	}
+}
+
+func TestDependencyCyclePathDetectsDirectCycle(t *testing.T) {
+	// #1 already depends on #2; making #2 depend on #1 deadlocks both.
+	tasks := []*task.Task{{ID: 1, DependsOn: []int{2}}, {ID: 2}}
+
+	assertChain(t, board.DependencyCyclePath(tasks, 2, 1), []int{2, 1, 2})
+}
+
+func TestDependencyCyclePathFollowsBranches(t *testing.T) {
+	// #1 depends on #2 and #3; only the #3 branch leads back to #4.
+	tasks := []*task.Task{
+		{ID: 1, DependsOn: []int{2, 3}},
+		{ID: 2},
+		{ID: 3, DependsOn: []int{4}},
+		{ID: 4},
+	}
+
+	if got := board.DependencyCyclePath(tasks, 4, 1); len(got) == 0 {
+		t.Error("DependencyCyclePath(4, 1) found no cycle, want the chain through #3")
+	}
+	if got := board.DependencyCyclePath(tasks, 4, 2); got != nil {
+		t.Errorf("DependencyCyclePath(4, 2) = %v, want no cycle", got)
+	}
+}
+
+func TestDependencyCyclePathAllowsDiamond(t *testing.T) {
+	// A diamond is not a cycle: #2 and #3 may both depend on #4.
+	tasks := []*task.Task{
+		{ID: 1, DependsOn: []int{2, 3}},
+		{ID: 2, DependsOn: []int{4}},
+		{ID: 3},
+		{ID: 4},
+	}
+
+	if got := board.DependencyCyclePath(tasks, 3, 4); got != nil {
+		t.Errorf("DependencyCyclePath(3, 4) = %v, want no cycle for a diamond", got)
+	}
+}
+
+func TestDependencyCyclePathSurvivesPreexistingCycle(t *testing.T) {
+	tasks := []*task.Task{
+		{ID: 1, DependsOn: []int{2}}, {ID: 2, DependsOn: []int{1}}, {ID: 3},
+	}
+
+	if got := board.DependencyCyclePath(tasks, 3, 1); got != nil {
+		t.Errorf("DependencyCyclePath(3, 1) = %v, want no cycle for a task outside the ring", got)
+	}
+}
+
+func TestDependencyCyclePathUnknownDependency(t *testing.T) {
+	if got := board.DependencyCyclePath([]*task.Task{{ID: 1}}, 1, 99); got != nil {
+		t.Errorf("DependencyCyclePath(1, 99) = %v, want no cycle", got)
+	}
+}
+
+func TestDependencyCyclePathSelfReference(t *testing.T) {
+	assertChain(t, board.DependencyCyclePath([]*task.Task{{ID: 1}}, 1, 1), []int{1, 1})
+}
+
+func TestDependencyCyclePathSkipsMissingLink(t *testing.T) {
+	// A dependency chain that runs into a deleted task ends there instead of
+	// reporting a ring.
+	tasks := []*task.Task{{ID: 1, DependsOn: []int{99}}, {ID: 2}}
+
+	if got := board.DependencyCyclePath(tasks, 2, 1); got != nil {
+		t.Errorf("DependencyCyclePath(2, 1) = %v, want no cycle across a missing link", got)
+	}
+}
+
+func TestEditRejectsParentCycle(t *testing.T) {
+	// The same rejection through the public Edit path, so the wiring in
+	// validateDeps is covered and not just the detector behind it.
+	cfg, _ := setupMutateBoard(t)
+	writeCycleTask(t, cfg, &task.Task{ID: 1, Title: "A", Status: "backlog"})
+	writeCycleTask(t, cfg, &task.Task{ID: 2, Title: "B", Status: "backlog"})
+
+	now := time.Now()
+	setParent := func(id int) func(*task.Task) (bool, error) {
+		return func(tk *task.Task) (bool, error) {
+			tk.Parent = &id
+			return true, nil
+		}
+	}
+
+	if _, err := board.Edit(cfg, 1, "", false, setParent(2), now); err != nil {
+		t.Fatalf("first parent edit: %v", err)
+	}
+
+	_, err := board.Edit(cfg, 2, "", false, setParent(1), now)
+	if err == nil {
+		t.Fatal("closing the ring succeeded, want a rejection")
+	}
+	if !containsSubstring(err.Error(), "cycle") {
+		t.Errorf("error = %q, want it to mention a cycle", err)
+	}
+	if !containsSubstring(err.Error(), "#2 → #1 → #2") {
+		t.Errorf("error = %q, want it to name the ring", err)
+	}
+}
+
+func TestEditRejectsDependencyCycle(t *testing.T) {
+	cfg, _ := setupMutateBoard(t)
+	writeCycleTask(t, cfg, &task.Task{ID: 1, Title: "A", Status: "backlog", DependsOn: []int{2}})
+	writeCycleTask(t, cfg, &task.Task{ID: 2, Title: "B", Status: "backlog"})
+
+	_, err := board.Edit(cfg, 2, "", false, func(tk *task.Task) (bool, error) {
+		tk.DependsOn = []int{1}
+		return true, nil
+	}, time.Now())
+
+	if err == nil {
+		t.Fatal("closing the dependency ring succeeded, want a rejection")
+	}
+	if !containsSubstring(err.Error(), "cycle") {
+		t.Errorf("error = %q, want it to mention a cycle", err)
+	}
+}
+
+func TestEditWithoutLinksSkipsTheCycleCheck(t *testing.T) {
+	// A task with neither parent nor dependencies must not pay for a board read.
+	cfg, _ := setupMutateBoard(t)
+	writeCycleTask(t, cfg, &task.Task{ID: 1, Title: "A", Status: "backlog"})
+
+	_, err := board.Edit(cfg, 1, "", false, func(tk *task.Task) (bool, error) {
+		tk.Title = "A renamed"
+		return true, nil
+	}, time.Now())
+	if err != nil {
+		t.Fatalf("plain edit was rejected: %v", err)
+	}
+}
+
+func writeCycleTask(t *testing.T, cfg *config.Config, tk *task.Task) {
+	t.Helper()
+	path := filepath.Join(cfg.TasksPath(), task.GenerateFilename(tk.ID, tk.Title))
+	if err := task.Write(path, tk); err != nil {
+		t.Fatalf("writing task #%d: %v", tk.ID, err)
+	}
+}

--- a/internal/board/mutate.go
+++ b/internal/board/mutate.go
@@ -347,7 +347,9 @@ func applyCreateParams(cfg *config.Config, t *task.Task, p CreateParams, now tim
 	return nil
 }
 
-// validateDeps validates parent and dependency references for a task.
+// validateDeps validates parent and dependency references for a task: every
+// referenced task must exist, and neither the parent tree nor the depends_on
+// graph may end up with a cycle.
 func validateDeps(cfg *config.Config, t *task.Task) error {
 	if t.Parent != nil {
 		if err := task.ValidateDependencyIDs(cfg.TasksPath(), t.ID, []int{*t.Parent}); err != nil {
@@ -357,6 +359,34 @@ func validateDeps(cfg *config.Config, t *task.Task) error {
 	if len(t.DependsOn) > 0 {
 		if err := task.ValidateDependencyIDs(cfg.TasksPath(), t.ID, t.DependsOn); err != nil {
 			return err
+		}
+	}
+	return validateAcyclic(cfg, t)
+}
+
+// validateAcyclic rejects a parent or dependency that would close a ring.
+//
+// The stored tasks still carry their previous links, and every new edge starts
+// at t, so any ring must run back to t through stored edges alone — reading the
+// board once is enough. Existence is already checked, so a read failure here
+// leaves the links unvalidated rather than blocking the edit.
+func validateAcyclic(cfg *config.Config, t *task.Task) error {
+	if t.Parent == nil && len(t.DependsOn) == 0 {
+		return nil
+	}
+	stored, _, err := task.ReadAllLenient(cfg.TasksPath())
+	if err != nil {
+		return nil
+	}
+
+	if t.Parent != nil {
+		if chain := ParentCyclePath(stored, t.ID, *t.Parent); chain != nil {
+			return task.ValidateParentCycle(chain)
+		}
+	}
+	for _, depID := range t.DependsOn {
+		if chain := DependencyCyclePath(stored, t.ID, depID); chain != nil {
+			return task.ValidateDependencyCycle(chain)
 		}
 	}
 	return nil

--- a/internal/clierr/clierr.go
+++ b/internal/clierr/clierr.go
@@ -21,6 +21,7 @@ const (
 	WIPLimitExceeded   = "WIP_LIMIT_EXCEEDED"
 	DependencyNotFound = "DEPENDENCY_NOT_FOUND"
 	SelfReference      = "SELF_REFERENCE"
+	CircularReference  = "CIRCULAR_REFERENCE"
 	NoChanges          = "NO_CHANGES"
 	BoundaryError      = "BOUNDARY_ERROR"
 	StatusConflict     = "STATUS_CONFLICT"

--- a/internal/task/validate.go
+++ b/internal/task/validate.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/antopolskiy/kanban-md/internal/clierr"
@@ -59,6 +61,32 @@ func ValidateSelfReference(id int) *clierr.Error {
 func ValidateDependencyNotFound(depID int) *clierr.Error {
 	return clierr.Newf(clierr.DependencyNotFound, "dependency task #%d not found", depID).
 		WithDetails(map[string]any{"id": depID})
+}
+
+// ValidateParentCycle returns a CLIError for a parent link that would close a
+// ring in the parent tree. chain names the ring, starting and ending at the
+// task being edited.
+func ValidateParentCycle(chain []int) *clierr.Error {
+	return clierr.Newf(clierr.CircularReference,
+		"parent would create a cycle (%s)", formatIDChain(chain)).
+		WithDetails(map[string]any{"chain": chain})
+}
+
+// ValidateDependencyCycle returns a CLIError for a dependency that would close
+// a ring in the depends_on graph, leaving every task on it permanently blocked.
+func ValidateDependencyCycle(chain []int) *clierr.Error {
+	return clierr.Newf(clierr.CircularReference,
+		"dependency would create a cycle (%s)", formatIDChain(chain)).
+		WithDetails(map[string]any{"chain": chain})
+}
+
+// formatIDChain renders a task ID chain as "#1 → #2 → #1".
+func formatIDChain(chain []int) string {
+	parts := make([]string, 0, len(chain))
+	for _, id := range chain {
+		parts = append(parts, "#"+strconv.Itoa(id))
+	}
+	return strings.Join(parts, " → ")
 }
 
 // ValidateWIPLimit returns a CLIError for WIP limit violations.


### PR DESCRIPTION
Closes #24.

`ValidateDependencyIDs` already rejects a task pointing at itself, but it only looks one link deep. A ring built in two steps passes today:

```bash
kanban-md edit 1 --parent 2   # Updated task #1: A
kanban-md edit 2 --parent 1   # Updated task #2: B   ← ring accepted
```

The parent tree then has no root. `depends_on` has the same hole, with a sharper symptom: every task on the ring is permanently blocked and `pick --unblocked` never offers any of them.

## What changed

- `ParentCyclePath` and `DependencyCyclePath` in `internal/board/cycle.go`, both returning the offending chain so the error can name it:

  ```
  $ kanban-md edit 2 --parent 1
  Error: parent would create a cycle (#2 → #1 → #2)
  ```

- Both are called from `validateDeps`, the single gate `Create` and `Edit` share, so `create --parent`, `edit --parent` and `edit --add-dep` are all covered by one change.
- New error code `CIRCULAR_REFERENCE` next to `SELF_REFERENCE`.

The parent tree allows one parent, so that walk is a chain. Dependencies form a graph, so that walk explores every branch and returns the first chain leading back.

## Design notes

- **Existing rings are tolerated, not trusted.** A board that already holds a ring keeps working: a walk that meets one ends rather than spinning, so an old ring cannot block an unrelated edit. Only the new link is judged.
- **Reading the board once is enough.** The stored tasks still carry their previous links and every new edge starts at the task being written, so any ring must run back through stored edges alone.
- **A read failure does not block the edit.** Existence is already validated by the check above; if the board cannot be re-read here, the link goes through unvalidated rather than the edit failing for an unrelated reason.
- **Valid moves stay valid**, including moving a subtree under a sibling, re-attaching to the current parent, and diamonds in `depends_on`.

## Verification

- `go test ./...` green. 21 new tests: 15 unit tests in `internal/board`, 5 e2e tests driving the real binary, plus one covering the skip path when a task has no links.
- 100% statement coverage on `cycle.go`; `validateAcyclic` at 91.7%, the gap being the board-read error path.
- **Mutation-checked:** removing the whole check makes 3 e2e tests fail; removing only the parent branch makes exactly the 2 parent e2e tests fail.
- `golangci-lint run ./...` reports 61 issues before and after — no new findings.
- README documents the new rejection under the hierarchy section.

Independent of #23; the two touch different files.